### PR TITLE
Use GATK and GOTC container images that use Amazon Corretto 11

### DIFF
--- a/example-workflows/_scripts/assets/omics-workflow-startrun-policy.json
+++ b/example-workflows/_scripts/assets/omics-workflow-startrun-policy.json
@@ -7,6 +7,7 @@
                 "s3:GetObject"
             ],
             "Resource": [
+                "arn:aws:s3:::omics-{{region}}/*",
                 "arn:aws:s3:::aws-genomics-static-{{region}}/*",
                 "arn:aws:s3:::{{staging_uri}}/*"
             ]
@@ -17,6 +18,7 @@
                 "s3:ListBucket"
             ],
             "Resource": [
+                "arn:aws:s3:::omics-{{region}}",
                 "arn:aws:s3:::aws-genomics-static-{{region}}"
             ]
         },

--- a/example-workflows/gatk-best-practices/containers/container_image_manifest.json
+++ b/example-workflows/gatk-best-practices/containers/container_image_manifest.json
@@ -1,6 +1,8 @@
 {
     "manifest": [
         "public.ecr.aws/aws-genomics/broadinstitute/gatk:4.2.6.1",
+        "public.ecr.aws/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-8",
+        "public.ecr.aws/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11",
         "public.ecr.aws/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z",
         "public.ecr.aws/docker/library/python:3.9",
         "public.ecr.aws/ubuntu/ubuntu:20.04"

--- a/example-workflows/gatk-best-practices/containers/container_image_manifest.json
+++ b/example-workflows/gatk-best-practices/containers/container_image_manifest.json
@@ -1,9 +1,8 @@
 {
     "manifest": [
-        "public.ecr.aws/aws-genomics/broadinstitute/gatk:4.2.6.1",
-        "public.ecr.aws/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-8",
         "public.ecr.aws/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11",
         "public.ecr.aws/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z",
+        "public.ecr.aws/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z-corretto-11",
         "public.ecr.aws/docker/library/python:3.9",
         "public.ecr.aws/ubuntu/ubuntu:20.04"
     ]

--- a/example-workflows/gatk-best-practices/containers/gatk-corretto/Dockerfile
+++ b/example-workflows/gatk-best-practices/containers/gatk-corretto/Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/aws-genomics/broadinstitute/gatk:4.2.6.1
+
+RUN wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.deb \
+ && apt-get install -f ./amazon-corretto-11-x64-linux-jdk.deb
+
+WORKDIR /gatk

--- a/example-workflows/gatk-best-practices/containers/gotc-corretto/Dockerfile
+++ b/example-workflows/gatk-best-practices/containers/gotc-corretto/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z
+
+RUN wget https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.deb \
+ && apt-get install -y -f ./amazon-corretto-11-x64-linux-jdk.deb
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+WORKDIR /usr/gitc

--- a/example-workflows/gatk-best-practices/workflows/analysis-ready-germline-bam-to-vcf/haplotypecaller-gvcf-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/analysis-ready-germline-bam-to-vcf/haplotypecaller-gvcf-gatk4.wdl
@@ -42,7 +42,7 @@ workflow HaplotypeCallerGvcf_GATK4 {
     Boolean make_gvcf = true
     Boolean make_bamout = false
 
-    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1"
+    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
     String utils_docker = ecr_registry + "/ecr-public/ubuntu/ubuntu:20.04"
     String gatk_path = "/gatk/gatk"
 

--- a/example-workflows/gatk-best-practices/workflows/analysis-ready-germline-bam-to-vcf/haplotypecaller-gvcf-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/analysis-ready-germline-bam-to-vcf/haplotypecaller-gvcf-gatk4.wdl
@@ -32,12 +32,12 @@ workflow HaplotypeCallerGvcf_GATK4 {
         String aws_region
     }
 
-    String src_bucket_name = "aws-genomics-static-" + aws_region
+    String src_bucket_name = "omics-" + aws_region
 
-    File ref_dict="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
-    File ref_fasta="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
-    File ref_fasta_index="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
-    File scattered_calling_intervals_archive="s3://" + src_bucket_name + "/omics-data/intervals/intervals.tar.gz"
+    File ref_dict="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
+    File ref_fasta="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
+    File ref_fasta_index="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+    File scattered_calling_intervals_archive="s3://" + src_bucket_name + "/intervals/intervals.tar.gz"
 
     Boolean make_gvcf = true
     Boolean make_bamout = false

--- a/example-workflows/gatk-best-practices/workflows/analysis-ready-germline-bam-to-vcf/test.parameters.json
+++ b/example-workflows/gatk-best-practices/workflows/analysis-ready-germline-bam-to-vcf/test.parameters.json
@@ -1,4 +1,4 @@
 {
-  "input_bam": "s3://aws-genomics-static-{{region}}/omics-data/bam/ERR194159-30x.hg38.bam",
-  "input_bam_index": "s3://aws-genomics-static-{{region}}/omics-data/bam/ERR194159-30x.hg38.bai"
+  "input_bam": "s3://omics-{{region}}/sample-inputs/5454617/ERR194159.hg38.5-percent.bam",
+  "input_bam_index": "s3://omics-{{region}}/sample-inputs/5454617/ERR194159.hg38.5-percent.bai"
 }

--- a/example-workflows/gatk-best-practices/workflows/cram-to-bam/cram-to-bam.wdl
+++ b/example-workflows/gatk-best-practices/workflows/cram-to-bam/cram-to-bam.wdl
@@ -21,7 +21,7 @@ workflow CramToBamFlow {
     File ref_fasta_index="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
     File ref_dict="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
 
-    String gitc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+    String gitc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z-corretto-11"
 
     #converts CRAM to SAM to BAM and makes BAI
     call CramToBamTask{

--- a/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/fastq-to-ubam.wdl
+++ b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/fastq-to-ubam.wdl
@@ -38,7 +38,7 @@ workflow ConvertPairedFastQsToUnmappedBamWf {
         String ecr_registry
     }
 
-    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1"
+    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
     String gatk_path = "/gatk/gatk"
 
 

--- a/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
@@ -72,7 +72,7 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
                                             ]
 
 
-  String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-8"
+  String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
   String gotc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
   String python_docker = ecr_registry + "/ecr-public/docker/library/python:3.9"
   String base_file_name = sample_name + "." + ref_name

--- a/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
@@ -48,27 +48,27 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
     String aws_region
   }
 
-  String src_bucket_name = "aws-genomics-static-" + aws_region
+  String src_bucket_name = "omics-" + aws_region
   
   String ref_name = "hg38"
-  File ref_fasta = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
-  File ref_fasta_index = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
-  File ref_dict = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
-  File ref_alt = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt"
-  File ref_sa = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa"
-  File ref_ann = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann"
-  File ref_bwt = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt"
-  File ref_pac = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac"
-  File ref_amb = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-  File dbSNP_vcf = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf"
-  File dbSNP_vcf_index = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx"
+  File ref_fasta = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
+  File ref_fasta_index = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+  File ref_dict = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
+  File ref_alt = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt"
+  File ref_sa = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa"
+  File ref_ann = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann"
+  File ref_bwt = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt"
+  File ref_pac = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac"
+  File ref_amb = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
+  File dbSNP_vcf = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf"
+  File dbSNP_vcf_index = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx"
   Array[File] known_indels_sites_VCFs = [
-                                        "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-                                        "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz"
+                                        "s3://" + src_bucket_name + "/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+                                        "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz"
                                         ]
   Array[File] known_indels_sites_indices = [
-                                            "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
-                                            "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
+                                            "s3://" + src_bucket_name + "/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
+                                            "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
                                             ]
 
 

--- a/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
@@ -72,7 +72,7 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
                                             ]
 
 
-  String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1"
+  String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-8"
   String gotc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
   String python_docker = ecr_registry + "/ecr-public/docker/library/python:3.9"
   String base_file_name = sample_name + "." + ref_name

--- a/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/sub-workflows/processing-for-variant-discovery-gatk4.wdl
@@ -73,7 +73,7 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
 
 
   String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
-  String gotc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+  String gotc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z-corretto-11"
   String python_docker = ecr_registry + "/ecr-public/docker/library/python:3.9"
   String base_file_name = sample_name + "." + ref_name
 

--- a/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/test.parameters.json
+++ b/example-workflows/gatk-best-practices/workflows/fastqs-to-analysis-ready-bam/test.parameters.json
@@ -3,26 +3,26 @@
   "fastq_pairs": [
     {
       "read_group": "C0L01ACXX.1",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0L01ACXX.1.R1.fastq.0.63.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0L01ACXX.1.R2.fastq.0.63.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/3768383/C0L01ACXX.1.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/3768383/C0L01ACXX.1.5-percent.R2.fastq.gz",
       "platform": "illumina"
     },
     {
       "read_group": "C0L01ACXX.2",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0L01ACXX.2.R1.fastq.0.63.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0L01ACXX.2.R2.fastq.0.63.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/3768383/C0L01ACXX.2.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/3768383/C0L01ACXX.2.5-percent.R2.fastq.gz",
       "platform": "illumina"
     },
     {
       "read_group": "C0L01ACXX.3",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0L01ACXX.3.R1.fastq.0.63.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0L01ACXX.3.R2.fastq.0.63.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/3768383/C0L01ACXX.3.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/3768383/C0L01ACXX.3.5-percent.R2.fastq.gz",
       "platform": "illumina"
     },
     {
       "read_group": "C0M7LACXX.7",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0M7LACXX.7.R1.fastq.0.63.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/downsampled/C0M7LACXX.7.R2.fastq.0.63.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/3768383/C0M7LACXX.7.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/3768383/C0M7LACXX.7.5-percent.R2.fastq.gz",
       "platform": "illumina"
     }
   ]

--- a/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/fastq-to-ubam.wdl
+++ b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/fastq-to-ubam.wdl
@@ -38,7 +38,7 @@ workflow ConvertPairedFastQsToUnmappedBamWf {
         String ecr_registry
     }
 
-    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1"
+    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
     String gatk_path = "/gatk/gatk"
 
 

--- a/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/haplotypecaller-gvcf-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/haplotypecaller-gvcf-gatk4.wdl
@@ -41,7 +41,7 @@ workflow HaplotypeCallerGvcf_GATK4 {
 
     Boolean make_gvcf = true
     Boolean make_bamout = false
-    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1"
+    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
     String utils_docker = ecr_registry + "/ecr-public/ubuntu/ubuntu:20.04"
     String gatk_path = "/gatk/gatk"
 

--- a/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/haplotypecaller-gvcf-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/haplotypecaller-gvcf-gatk4.wdl
@@ -32,12 +32,12 @@ workflow HaplotypeCallerGvcf_GATK4 {
         String aws_region
     }
 
-    String src_bucket_name = "aws-genomics-static-" + aws_region
+    String src_bucket_name = "omics-" + aws_region
 
-    File ref_dict="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
-    File ref_fasta="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
-    File ref_fasta_index="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
-    File scattered_calling_intervals_archive="s3://" + src_bucket_name + "/omics-data/intervals/intervals.tar.gz"
+    File ref_dict="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
+    File ref_fasta="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
+    File ref_fasta_index="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+    File scattered_calling_intervals_archive="s3://" + src_bucket_name + "/intervals/intervals.tar.gz"
 
     Boolean make_gvcf = true
     Boolean make_bamout = false

--- a/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl
@@ -72,7 +72,7 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
                                             "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
                                             ]
 
-  String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1"
+  String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
   String gotc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
   String python_docker = ecr_registry + "/ecr-public/docker/library/python:3.9"
   String base_file_name = sample_name + "." + ref_name

--- a/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl
@@ -73,7 +73,7 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
                                             ]
 
   String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"
-  String gotc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z"
+  String gotc_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/genomes-in-the-cloud:2.5.7-2021-06-09_16-47-48Z-corretto-11"
   String python_docker = ecr_registry + "/ecr-public/docker/library/python:3.9"
   String base_file_name = sample_name + "." + ref_name
 

--- a/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl
+++ b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/sub-workflows/processing-for-variant-discovery-gatk4.wdl
@@ -49,27 +49,27 @@ workflow PreProcessingForVariantDiscovery_GATK4 {
     String aws_region
   }
 
-  String src_bucket_name = "aws-genomics-static-" + aws_region
+  String src_bucket_name = "omics-" + aws_region
   
   String ref_name = "hg38"
-  File ref_fasta = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
-  File ref_fasta_index = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
-  File ref_dict = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
-  File ref_alt = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt"
-  File ref_sa = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa"
-  File ref_ann = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann"
-  File ref_bwt = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt"
-  File ref_pac = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac"
-  File ref_amb = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
-  File dbSNP_vcf = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf"
-  File dbSNP_vcf_index = "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx"
+  File ref_fasta = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
+  File ref_fasta_index = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+  File ref_dict = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
+  File ref_alt = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.alt"
+  File ref_sa = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.sa"
+  File ref_ann = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.ann"
+  File ref_bwt = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.bwt"
+  File ref_pac = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.pac"
+  File ref_amb = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.64.amb"
+  File dbSNP_vcf = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf"
+  File dbSNP_vcf_index = "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dbsnp138.vcf.idx"
   Array[File] known_indels_sites_VCFs = [
-                                        "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-                                        "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz"
+                                        "s3://" + src_bucket_name + "/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+                                        "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz"
                                         ]
   Array[File] known_indels_sites_indices = [
-                                            "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
-                                            "s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
+                                            "s3://" + src_bucket_name + "/broad-references/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
+                                            "s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
                                             ]
 
   String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11"

--- a/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/test.parameters.json
+++ b/example-workflows/gatk-best-practices/workflows/germline-fastqs-to-vcf/test.parameters.json
@@ -3,26 +3,26 @@
   "fastq_pairs": [
     {
       "read_group": "C0L01ACXX.1",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0L01ACXX.1.R1.fastq.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0L01ACXX.1.R2.fastq.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/9500764/C0L01ACXX.1.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/9500764/C0L01ACXX.1.5-percent.R2.fastq.gz",
       "platform": "illumina"
     },
     {
       "read_group": "C0L01ACXX.2",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0L01ACXX.2.R1.fastq.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0L01ACXX.2.R2.fastq.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/9500764/C0L01ACXX.2.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/9500764/C0L01ACXX.2.5-percent.R2.fastq.gz",
       "platform": "illumina"
     },
     {
       "read_group": "C0L01ACXX.3",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0L01ACXX.3.R1.fastq.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0L01ACXX.3.R2.fastq.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/9500764/C0L01ACXX.3.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/9500764/C0L01ACXX.3.5-percent.R2.fastq.gz",
       "platform": "illumina"
     },
     {
       "read_group": "C0M7LACXX.7",
-      "fastq_1": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0M7LACXX.7.R1.fastq.gz",
-      "fastq_2": "s3://aws-genomics-static-{{region}}/omics-data/fastq/ERR194159/C0M7LACXX.7.R2.fastq.gz",
+      "fastq_1": "s3://omics-{{region}}/sample-inputs/9500764/C0M7LACXX.7.5-percent.R1.fastq.gz",
+      "fastq_2": "s3://omics-{{region}}/sample-inputs/9500764/C0M7LACXX.7.5-percent.R2.fastq.gz",
       "platform": "illumina"
     }
   ]

--- a/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl
+++ b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl
@@ -107,7 +107,7 @@ workflow Mutect2 {
     File ref_fai="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
     File ref_dict="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
 
-    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1" 
+    String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11" 
     Runtime standard_runtime = Runtime {"gatk_docker": gatk_docker,
                                         "cpu": small_task_cpu,
                                         "machine_mem": small_task_mem * 1024,

--- a/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl
+++ b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl
@@ -103,10 +103,10 @@ workflow Mutect2 {
         Int filter_alignment_artifacts_mem = 9216
     }
 
-    String src_bucket_name = "aws-genomics-static-" + aws_region
-    File ref_fasta="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
-    File ref_fai="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
-    File ref_dict="s3://" + src_bucket_name + "/omics-data/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
+    String src_bucket_name = "omics-" + aws_region
+    File ref_fasta="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta"
+    File ref_fai="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.fasta.fai"
+    File ref_dict="s3://" + src_bucket_name + "/broad-references/hg38/v0/Homo_sapiens_assembly38.dict"
 
     String gatk_docker = ecr_registry + "/ecr-public/aws-genomics/broadinstitute/gatk:4.2.6.1-corretto-11" 
     Runtime standard_runtime = Runtime {"gatk_docker": gatk_docker,

--- a/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl
+++ b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/mutec2.wdl
@@ -93,6 +93,7 @@ workflow Mutect2 {
 
         # runtime
         String ecr_registry
+        String aws_region
         Int scatter_count=50
 
         Int small_task_cpu = 2

--- a/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/test.parameters.json
+++ b/example-workflows/gatk-best-practices/workflows/somatic-snps-and-indels/test.parameters.json
@@ -1,8 +1,8 @@
 {
-  "tumor_reads": "s3://aws-genomics-static-{{region}}/omics-data/tumor-normal/bams/SRR2089363.hg38.bam",
-  "tumor_reads_index": "s3://aws-genomics-static-{{region}}/omics-data/tumor-normal/bams/SRR2089363.hg38.bai",
-  "normal_reads": "s3://aws-genomics-static-{{region}}/omics-data/tumor-normal/bams/SRR2089364.hg38.bam",
-  "normal_reads_index": "s3://aws-genomics-static-{{region}}/omics-data/tumor-normal/bams/SRR2089364.hg38.bai",
-  "gnomad": "s3://aws-genomics-static-{{region}}/omics-data/gnomad/v3.1.2/gnomad.genomes.v3.1.2.sites.af-only.vcf.gz",
-  "gnomad_idx": "s3://aws-genomics-static-{{region}}/omics-data/gnomad/v3.1.2/gnomad.genomes.v3.1.2.sites.af-only.vcf.gz.tbi"
+  "tumor_reads": "s3://omics-{{region}}/sample-inputs/5562080/SRR2089363.hg38.bam",
+  "tumor_reads_index": "s3://omics-{{region}}/sample-inputs/5562080/SRR2089363.hg38.bai",
+  "normal_reads": "s3://omics-{{region}}/sample-inputs/5562080/SRR2089364.hg38.bam",
+  "normal_reads_index": "s3://omics-{{region}}/sample-inputs/5562080/SRR2089364.hg38.bai",
+  "gnomad": "s3://omics-{{region}}/gnomad/v3.1.2/gnomad.genomes.v3.1.2.sites.af-only.vcf.gz",
+  "gnomad_idx": "s3://omics-{{region}}/gnomad/v3.1.2/gnomad.genomes.v3.1.2.sites.af-only.vcf.gz.tbi"
 }


### PR DESCRIPTION
*Issue #, if available:*
* #23 

*Description of changes:*
* pull GATK and GOTC container images that use Amazon Corretto 11 to match R2R implementations
* update container uris in gatk-best-practice workflows
* update test data uris for gatk-best-practice workflows to use data from `s3://omics-*` buckets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
