### PR TITLE
remove unused local container build functions

### DIFF
--- a/example-workflows/_conf/default.ini
+++ b/example-workflows/_conf/default.ini
@@ -5,16 +5,6 @@
 # aws region to use, region configured with selected profile is used
 # region = us-east-1
 
-# docker-cli compatible client binary
-# only used if you want to build container images locally
-# scripts here have been tested with docker-cli, but others like finch and podman may work
-# whale_client = docker
-
-# allow overwriting resources in ecr like permissions policies or images
-# only used if you want to build container images locally and push to ecr via make
-# it is recommended to use the omx-ecr-helper CDK app to build or retrieve publicly available container images
-# allow_ecr_overwrite = True
-
 # staging uri for workflow bundles if you want a specific location for this
 # if not specified, output_uri is used
 # used if workflow bundles are larger than 4MiB in size. must be in the same region workflows are run in.

--- a/example-workflows/_scripts/build.py
+++ b/example-workflows/_scripts/build.py
@@ -18,9 +18,6 @@ parser.add_argument(
 subparsers = parser.add_subparsers(dest='subcommand')
 
 parser_config = subparsers.add_parser('config')
-parser_ecr = subparsers.add_parser('ecr')
-parser_ecr.add_argument(
-    'image_name', type=str, help="name of image to build (e.g. 'tool:tag')")
 
 parser_s3 = subparsers.add_parser('s3')
 parser_iam = subparsers.add_parser('iam')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes functions for local container image builds using `python_on_whales`. Container image builds are done with `omx-ecr-helper`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
