### PR TITLE
fix issue #30

### DIFF
--- a/utils/cdk/omx-ecr-helper/lib/container-puller-stack.ts
+++ b/utils/cdk/omx-ecr-helper/lib/container-puller-stack.ts
@@ -221,6 +221,17 @@ export class ContainerPullerStack extends cdk.Stack {
                                         ],
                                         resultPath: '$.repository.created'
                                     })
+                                    // multiple images targeting the same repository creates a race condition
+                                    // catch the "repository already exists error"
+                                    .addCatch(
+                                        new sfn.Pass(this, 'ECR Repository Already Exists', {
+                                            parameters: { "image.$": "$.image" }
+                                        }).next(ProcessImageURI),
+                                        { 
+                                            errors: [ "Ecr.RepositoryAlreadyExistsException" ],
+                                            resultPath: "$.error"
+                                        }
+                                    )
                                     .next(ProcessImageURI)
                                 )
                                 .next(


### PR DESCRIPTION
*Issue #, if available:*
#30 

*Description of changes:*
Add catch for `Ecr.RepositoryAlreadyExistsException` to `ECR Create Repository` task to handle race conditions caused by manifests with multiple images targeting the same parent repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
