### PR TITLE
Update 200-omics_storage.ipynb

### DIFF
--- a/notebooks/200-omics_storage.ipynb
+++ b/notebooks/200-omics_storage.ipynb
@@ -1095,7 +1095,7 @@
    "source": [
     "# download a part of the readset\n",
     "response = omics.get_read_set(sequenceStoreId=readset['sequenceStoreId'], id=readset['id'], partNumber=1, file='SOURCE1')\n",
-    "with open(f\"reads1.part.{readset_metadata['fileType'].lower()}\", 'wb') as f:\n",
+    "with open(f\"reads1.part.{readset_metadata['fileType'].lower()}.gz\", 'wb') as f:\n",
     "    f.write(response['payload'].read())"
    ]
   }


### PR DESCRIPTION
fixes #3

*Issue #, if available:*
#3 

*Description of changes:*
Downloaded data is gzip compressed. The downloaded file on filesystem should have the correct extension to be read by other tooling correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
