### PR TITLE
make inspect_nf compatible with new registry specification from nfcore

### DIFF
--- a/example-workflows/.gitignore
+++ b/example-workflows/.gitignore
@@ -1,2 +1,2 @@
-build/
+*/build/
 _conf/default.ini.*

--- a/example-workflows/README.md
+++ b/example-workflows/README.md
@@ -12,6 +12,7 @@ These are provided AS-IS and are intended to demonstrate conventions, patterns, 
     - Python 3.9 or higher
     - Python packages: see `_scripts/requirements.txt`
     - make
+    - CDK should be bootstrapped to your account and region. See https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html
 
 ```bash
 cd _scripts/

--- a/example-workflows/README.md
+++ b/example-workflows/README.md
@@ -47,11 +47,7 @@ make run-{workflow_name}
 ```
 
 See README files in each workflow group for any special cases.
-> CURRENT EXCEPTIONS:
->  
->  - HISAT-Genotype HLA Caller 
->
-> Use instructions for set up provided in the README for these workflows
+
 
 ## Further reading
 

--- a/example-workflows/_scripts/builder/__init__.py
+++ b/example-workflows/_scripts/builder/__init__.py
@@ -44,8 +44,7 @@ class Builder:
         cfg = CONFIG_DEFAULTS
         cfg |= { key: config['default'].get(key) for key in CONFIG_DEFAULTS if config['default'].get(key) }
 
-        #session = boto3.Session(profile_name=cfg['profile'], region_name=cfg['region'])
-        session = boto3.Session(region_name=cfg['region'])
+        session = boto3.Session(profile_name=cfg.get('profile'), region_name=cfg.get('region'))  
         account_id = session.client('sts').get_caller_identity()['Account']
         profile_name = session.profile_name
         region_name = session.region_name

--- a/example-workflows/_scripts/common.mk
+++ b/example-workflows/_scripts/common.mk
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 
 scripts = ../_scripts
 assets = ../_scripts/assets
-config = ../_conf/default.ini.omicsee
+config = ../_conf/default.ini
 
 omx_ecr_helper = $(shell jq -r '.omx_ecr_helper' build/config.json)
 profile = $(shell jq -r '.profile' build/config.json)

--- a/example-workflows/gatk-best-practices/README.md
+++ b/example-workflows/gatk-best-practices/README.md
@@ -15,6 +15,7 @@ These are provided AS-IS and are intended to demonstrate conventions, patterns, 
     - Python 3.9 or higher
     - Python packages: see `requirements.txt`
     - make
+    - CDK should be bootstrapped to your account and region. See https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html
 
 To install Python package requirements use:
 ```bash

--- a/example-workflows/nf-core/README.md
+++ b/example-workflows/nf-core/README.md
@@ -15,6 +15,7 @@ These are provided AS-IS and are intended to demonstrate conventions, patterns, 
     - Python 3.9 or higher
     - Python packages: see `requirements.txt`
     - make
+    - CDK should be bootstrapped to your account and region. See https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html
 
 To install Python package requirements use:
 ```bash

--- a/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/build/main.nf
+++ b/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/build/main.nf
@@ -1,0 +1,63 @@
+process HISAT2_BUILD {
+    tag "$fasta"
+    label 'process_high'
+    label 'process_high_memory'
+
+    // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/hisat2:2.2.1--h1b792b2_3' :
+        'quay.io/biocontainers/hisat2:2.2.1--h1b792b2_3' }"
+
+    input:
+    path fasta
+    path gtf
+    path splicesites
+
+    output:
+    path "hisat2"       , emit: index
+    path "versions.yml" , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def avail_mem = 0
+    if (!task.memory) {
+        log.info "[HISAT2 index build] Available memory not known - defaulting to 0. Specify process memory requirements to change this."
+    } else {
+        log.info "[HISAT2 index build] Available memory: ${task.memory}"
+        avail_mem = task.memory.toGiga()
+    }
+
+    def ss = ''
+    def exon = ''
+    def extract_exons = ''
+    def hisat2_build_memory = params.hisat2_build_memory ? (params.hisat2_build_memory as nextflow.util.MemoryUnit).toGiga() : 0
+    if (avail_mem >= hisat2_build_memory) {
+        log.info "[HISAT2 index build] At least ${hisat2_build_memory} GB available, so using splice sites and exons to build HISAT2 index"
+        extract_exons = "hisat2_extract_exons.py $gtf > ${gtf.baseName}.exons.txt"
+        ss = "--ss $splicesites"
+        exon = "--exon ${gtf.baseName}.exons.txt"
+    } else {
+        log.info "[HISAT2 index build] Less than ${hisat2_build_memory} GB available, so NOT using splice sites and exons to build HISAT2 index."
+        log.info "[HISAT2 index build] Use --hisat2_build_memory [small number] to skip this check."
+    }
+    def VERSION = '2.2.1' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    """
+    mkdir -p hisat2
+    $extract_exons
+    hisat2-build \\
+        -p $task.cpus \\
+        $ss \\
+        $exon \\
+        $args \\
+        $fasta \\
+        hisat2/${fasta.baseName}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hisat2: $VERSION
+    END_VERSIONS
+    """
+}

--- a/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/build/meta.yml
+++ b/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/build/meta.yml
@@ -1,0 +1,42 @@
+name: hisat2_build
+description: Builds HISAT2 index for reference genome
+keywords:
+  - build
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - hisat2:
+      description: HISAT2 is a fast and sensitive alignment program for mapping next-generation sequencing reads (both DNA and RNA) to a population of human genomes as well as to a single reference genome.
+      homepage: https://daehwankimlab.github.io/hisat2/
+      documentation: https://daehwankimlab.github.io/hisat2/manual/
+      doi: "10.1038/s41587-019-0201-4"
+      licence: ["MIT"]
+
+input:
+  - fasta:
+      type: file
+      description: Reference fasta file
+      pattern: "*.{fa,fasta,fna}"
+  - gtf:
+      type: file
+      description: Reference gtf annotation file
+      pattern: "*.{gtf}"
+  - splicesites:
+      type: file
+      description: Splices sites in gtf file
+      pattern: "*.{txt}"
+
+output:
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - index:
+      type: file
+      description: HISAT2 genome index file
+      pattern: "*.ht2"
+
+authors:
+  - "@ntoda03"

--- a/example-workflows/nf-core/workflows/taxprofiler/modules/nf-core/bowtie2/build/main.nf
+++ b/example-workflows/nf-core/workflows/taxprofiler/modules/nf-core/bowtie2/build/main.nf
@@ -1,0 +1,30 @@
+process BOWTIE2_BUILD {
+    tag "$fasta"
+    label 'process_high'
+
+    conda "bioconda::bowtie2=2.4.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bowtie2:2.4.4--py39hbb4e92a_0' :
+        'quay.io/biocontainers/bowtie2:2.4.4--py39hbb4e92a_0' }"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path('bowtie2')    , emit: index
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    mkdir -p bowtie2
+    bowtie2-build $args --threads $task.cpus $fasta bowtie2/${fasta.baseName}
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bowtie2: \$(echo \$(bowtie2 --version 2>&1) | sed 's/^.*bowtie2-align-s version //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/example-workflows/nf-core/workflows/taxprofiler/modules/nf-core/bowtie2/build/meta.yml
+++ b/example-workflows/nf-core/workflows/taxprofiler/modules/nf-core/bowtie2/build/meta.yml
@@ -1,0 +1,43 @@
+name: bowtie2_build
+description: Builds bowtie index for reference genome
+keywords:
+  - build
+  - index
+  - fasta
+  - genome
+  - reference
+tools:
+  - bowtie2:
+      description: |
+        Bowtie 2 is an ultrafast and memory-efficient tool for aligning
+        sequencing reads to long reference sequences.
+      homepage: http://bowtie-bio.sourceforge.net/bowtie2/index.shtml
+      documentation: http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml
+      doi: 10.1038/nmeth.1923
+      licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test', single_end:false ]
+  - fasta:
+      type: file
+      description: Input genome fasta file
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test', single_end:false ]
+  - index:
+      type: file
+      description: Bowtie2 genome index files
+      pattern: "*.bt2"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/example-workflows/other_WDL/README.md
+++ b/example-workflows/other_WDL/README.md
@@ -15,6 +15,7 @@ These are provided AS-IS and are intended to demonstrate conventions, patterns, 
     - Python 3.9 or higher
     - Python packages: see `requirements.txt`
     - make
+    - CDK should be bootstrapped to your account and region. See https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html
 
 To install Python package requirements use:
 ```bash

--- a/example-workflows/protein-folding/README.md
+++ b/example-workflows/protein-folding/README.md
@@ -15,6 +15,7 @@ These are provided AS-IS and are intended to demonstrate conventions, patterns, 
     - Python 3.9 or higher
     - Python packages: see `requirements.txt`
     - make
+    - CDK should be bootstrapped to your account and region. See https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html
 
 To install Python package requirements use:
 ```bash

--- a/utils/scripts/inspect_nf.py
+++ b/utils/scripts/inspect_nf.py
@@ -38,7 +38,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '-n', '--namespace-config', type=str,
-    help="JSON file with public registry to ecr repository namespace mappings. This should be the same as what is used by omx-ecr-helper."
+    help="JSON file with public registry to ecr repository namespace mappings. This should be the same as what is used by omx-ecr-helper. (e.g. omx-ecr-helper/lib/lambda/parse-image-uri/public_registry_properties.json)"
 )
 parser.add_argument(
     '--output-manifest-file', type=str,

--- a/utils/scripts/nf/__init__.py
+++ b/utils/scripts/nf/__init__.py
@@ -158,7 +158,7 @@ class NextflowWorkflow:
         for uri in self.containers:
             if substitutions and uri in substitutions:
                 uri = substitutions.get(uri)
-            if self.docker_registry is not None:
+            if self.docker_registry:
                 uri = "/".join([self.docker_registry, uri])
             uris.add(uri)
         
@@ -168,7 +168,7 @@ class NextflowWorkflow:
         if substitutions and uri in substitutions:
             uri = substitutions.get(uri)
 
-        if self.docker_registry is not None:
+        if self.docker_registry:
             uri = "/".join([self.docker_registry, uri])
 
         if namespace_config:

--- a/utils/scripts/nf/__init__.py
+++ b/utils/scripts/nf/__init__.py
@@ -101,6 +101,7 @@ class NextflowWorkflow:
         self._nf_files = glob(path.join(project_path, '**/*.nf'), recursive=True)
         self.use_ecr_pull_through_cache = True
         self._container_substitutions = None
+        self._nf_config = path.join(project_path, 'nextflow.config')
     
     @property
     def _contents(self) -> dict:
@@ -129,6 +130,25 @@ class NextflowWorkflow:
                 uris.add(process.container)
         
         return sorted(list(uris))
+    
+    @property
+    def docker_registry(self) -> str:
+        """
+        returns the docker registry specified by the workflow definition
+        specified in its own line in a nextflow.config file as 
+        docker.registry = 'quay.io'
+        """
+        _docker_registry = None
+        try:
+            with open(self._nf_config, 'r') as _file:
+                for line in _file:
+                    if line.startswith('docker.registry'):
+                        _docker_registry = line.strip().split('=')[1].replace('\'', '').replace('"', '').strip()
+                        break
+        except FileNotFoundError as fnfe:
+            print(f"nextflow.config file not found in project directory: {self._project_path}")
+            raise fnfe
+        return _docker_registry
         
     def get_container_manifest(self, substitutions=None) -> list:
         """
@@ -138,6 +158,8 @@ class NextflowWorkflow:
         for uri in self.containers:
             if substitutions and uri in substitutions:
                 uri = substitutions.get(uri)
+            if self.docker_registry is not None:
+                uri = "/".join([self.docker_registry, uri])
             uris.add(uri)
         
         return sorted(list(uris))
@@ -145,6 +167,9 @@ class NextflowWorkflow:
     def _get_ecr_image_name(self, uri, substitutions=None, namespace_config=None):
         if substitutions and uri in substitutions:
             uri = substitutions.get(uri)
+
+        if self.docker_registry is not None:
+            uri = "/".join([self.docker_registry, uri])
 
         if namespace_config:
             uri_parts = uri.split('/')

--- a/utils/scripts/tests/workflow_with_config/main.nf
+++ b/utils/scripts/tests/workflow_with_config/main.nf
@@ -1,0 +1,14 @@
+include { HAPPY } from "./processes/happy.nf"
+include { NO_CONTAINER } from "./processes/no_container.nf"
+include { FOO, BAR } from "./processes/multiple.nf"
+
+workflow MAIN {
+    HAPPY()
+    NO_CONTAINER()
+    FOO()
+    BAR()
+}
+
+workflow {
+    MAIN()
+}

--- a/utils/scripts/tests/workflow_with_config/nextflow.config
+++ b/utils/scripts/tests/workflow_with_config/nextflow.config
@@ -1,0 +1,241 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    omicsqc/omicsqc Nextflow config file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Default config options for all compute environments
+----------------------------------------------------------------------------------------
+*/
+
+// Global default params, used in configs
+params {
+
+    // TODO nf-core: Specify your pipeline's command line flags
+    // Input options
+    input                      = null
+
+
+    // References
+    genome                     = null
+    igenomes_base              = 's3://ngi-igenomes/igenomes'
+    igenomes_ignore            = false
+    // MultiQC options
+    multiqc_config             = null
+    multiqc_title              = null
+    multiqc_logo               = null
+    max_multiqc_email_size     = '25.MB'
+    multiqc_methods_description = null
+
+    // Boilerplate options
+    outdir                     = null
+    tracedir                   = "${params.outdir}/pipeline_info"
+    publish_dir_mode           = 'copy'
+    email                      = null
+    email_on_fail              = null
+    plaintext_email            = false
+    monochrome_logs            = false
+    hook_url                   = null
+    help                       = false
+    version                    = false
+    validate_params            = true
+    show_hidden_params         = false
+    schema_ignore_params       = 'genomes'
+
+
+    // Config options
+    custom_config_version      = 'master'
+    custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
+    config_profile_description = null
+    config_profile_contact     = null
+    config_profile_url         = null
+    config_profile_name        = null
+
+
+    // Max resource options
+    // Defaults only, expecting to be overwritten
+    max_memory                 = '128.GB'
+    max_cpus                   = 16
+    max_time                   = '240.h'
+
+}
+
+// Load base.config by default for all pipelines
+includeConfig 'conf/base.config'
+
+// Load nf-core custom profiles from different Institutions
+try {
+    includeConfig "${params.custom_config_base}/nfcore_custom.config"
+} catch (Exception e) {
+    System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
+}
+
+// Load omicsqc/omicsqc custom profiles from different institutions.
+// Warning: Uncomment only if a pipeline-specific instititutional config already exists on nf-core/configs!
+// try {
+//   includeConfig "${params.custom_config_base}/pipeline/omicsqc.config"
+// } catch (Exception e) {
+//   System.err.println("WARNING: Could not load nf-core/config/omicsqc profiles: ${params.custom_config_base}/pipeline/omicsqc.config")
+// }
+
+
+profiles {
+    debug { process.beforeScript = 'echo $HOSTNAME' }
+    conda {
+        conda.enabled          = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+    mamba {
+        conda.enabled          = true
+        conda.useMamba         = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+    docker {
+        docker.enabled         = true
+        docker.userEmulation   = true
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+    arm {
+        docker.runOptions = '-u $(id -u):$(id -g) --platform=linux/amd64'
+    }
+    singularity {
+        singularity.enabled    = true
+        singularity.autoMounts = true
+        docker.enabled         = false
+        podman.enabled         = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+    podman {
+        podman.enabled         = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        shifter.enabled        = false
+        charliecloud.enabled   = false
+    }
+    shifter {
+        shifter.enabled        = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        charliecloud.enabled   = false
+    }
+    charliecloud {
+        charliecloud.enabled   = true
+        docker.enabled         = false
+        singularity.enabled    = false
+        podman.enabled         = false
+        shifter.enabled        = false
+    }
+    gitpod {
+        executor.name          = 'local'
+        executor.cpus          = 16
+        executor.memory        = 60.GB
+    }
+    test      { includeConfig 'conf/test.config'      }
+    test_full { includeConfig 'conf/test_full.config' }
+}
+
+
+// Load igenomes.config if required
+if (!params.igenomes_ignore) {
+    includeConfig 'conf/igenomes.config'
+} else {
+    params.genomes = [:]
+}
+
+
+// Export these variables to prevent local Python/R libraries from conflicting with those in the container
+// The JULIA depot path has been adjusted to a fixed path `/usr/local/share/julia` that needs to be used for packages in the container.
+// See https://apeltzer.github.io/post/03-julia-lang-nextflow/ for details on that. Once we have a common agreement on where to keep Julia packages, this is adjustable.
+
+env {
+    PYTHONNOUSERSITE = 1
+    R_PROFILE_USER   = "/.Rprofile"
+    R_ENVIRON_USER   = "/.Renviron"
+    JULIA_DEPOT_PATH = "/usr/local/share/julia"
+}
+
+// Capture exit codes from upstream processes when piping
+process.shell = ['/bin/bash', '-euo', 'pipefail']
+
+def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+timeline {
+    enabled = true
+    file    = "${params.tracedir}/execution_timeline_${trace_timestamp}.html"
+}
+report {
+    enabled = true
+    file    = "${params.tracedir}/execution_report_${trace_timestamp}.html"
+}
+trace {
+    enabled = true
+    file    = "${params.tracedir}/execution_trace_${trace_timestamp}.txt"
+}
+dag {
+    enabled = true
+    file    = "${params.tracedir}/pipeline_dag_${trace_timestamp}.html"
+}
+
+manifest {
+    name            = 'omicsqc/omicsqc'
+    author          = """Fernando Izquierdo"""
+    homePage        = 'https://github.com/omicsqc/omicsqc'
+    description     = """test workflow fastqc"""
+    mainScript      = 'main.nf'
+    nextflowVersion = '!>=22.10.1'
+    version         = '1.0dev'
+    doi             = ''
+}
+
+// Load modules.config for DSL2 module specific options
+includeConfig 'conf/modules.config'
+
+// Set default registry for Docker and Podman independent of -profile
+// Will not be used unless Docker / Podman are enabled
+// Set to your registry if you have a mirror of containers
+docker.registry = 'quay.io'
+podman.registry = 'quay.io'
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+def check_max(obj, type) {
+    if (type == 'memory') {
+        try {
+            if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+                return params.max_memory as nextflow.util.MemoryUnit
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'time') {
+        try {
+            if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+                return params.max_time as nextflow.util.Duration
+            else
+                return obj
+        } catch (all) {
+            println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+            return obj
+        }
+    } else if (type == 'cpus') {
+        try {
+            return Math.min( obj, params.max_cpus as int )
+        } catch (all) {
+            println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+            return obj
+        }
+    }
+}
+includeConfig 'conf/omics.config'

--- a/utils/scripts/tests/workflow_with_config/processes/cellranger/count/main.nf
+++ b/utils/scripts/tests/workflow_with_config/processes/cellranger/count/main.nf
@@ -1,0 +1,54 @@
+process CELLRANGER_COUNT {
+    tag "$meta.gem"
+    label 'process_high'
+
+    container "nfcore/cellranger:7.1.0"
+
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        exit 1, "CELLRANGER_COUNT module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
+
+    input:
+    tuple val(meta), path(reads)
+    path  reference
+
+    output:
+    tuple val(meta), path("sample-${meta.gem}/outs/*"), emit: outs
+    path "versions.yml"                               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def sample_arg = meta.samples.unique().join(",")
+    def reference_name = reference.name
+    """
+    cellranger \\
+        count \\
+        --id='sample-${meta.gem}' \\
+        --fastqs=. \\
+        --transcriptome=$reference_name \\
+        --sample=$sample_arg \\
+        --localcores=$task.cpus \\
+        --localmem=${task.memory.toGiga()} \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        cellranger: \$(echo \$( cellranger --version 2>&1) | sed 's/^.*[^0-9]\\([0-9]*\\.[0-9]*\\.[0-9]*\\).*\$/\\1/' )
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    mkdir -p "sample-${meta.gem}/outs/"
+    touch sample-${meta.gem}/outs/fake_file.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        cellranger: \$(echo \$( cellranger --version 2>&1) | sed 's/^.*[^0-9]\\([0-9]*\\.[0-9]*\\.[0-9]*\\).*\$/\\1/' )
+    END_VERSIONS
+    """
+}

--- a/utils/scripts/tests/workflow_with_config/processes/gunzip/main.nf
+++ b/utils/scripts/tests/workflow_with_config/processes/gunzip/main.nf
@@ -1,0 +1,44 @@
+process GUNZIP {
+    tag "$archive"
+    label 'process_single'
+
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/ubuntu:20.04' :
+        'ubuntu:20.04' }"
+
+    input:
+    tuple val(meta), path(archive)
+
+    output:
+    tuple val(meta), path("$gunzip"), emit: gunzip
+    path "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    gunzip = archive.toString() - '.gz'
+    """
+    gunzip \\
+        -f \\
+        $args \\
+        $archive
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    gunzip = archive.toString() - '.gz'
+    """
+    touch $gunzip
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
+    END_VERSIONS
+    """
+}

--- a/utils/scripts/tests/workflow_with_config/processes/gunzip/meta.yml
+++ b/utils/scripts/tests/workflow_with_config/processes/gunzip/meta.yml
@@ -1,0 +1,34 @@
+name: gunzip
+description: Compresses and decompresses files.
+keywords:
+  - gunzip
+  - compression
+tools:
+  - gunzip:
+    description: |
+      gzip is a file format and a software application used for file compression and decompression.
+    documentation: https://www.gnu.org/software/gzip/manual/gzip.html
+    licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+    type: map
+    description: |
+      Optional groovy Map containing meta information
+      e.g. [ id:'test', single_end:false ]
+  - archive:
+    type: file
+    description: File to be compressed/uncompressed
+    pattern: "*.*"
+output:
+  - gunzip:
+    type: file
+    description: Compressed/uncompressed file
+    pattern: "*.*"
+  - versions:
+    type: file
+    description: File containing software versions
+    pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@jfy133"

--- a/utils/scripts/tests/workflow_with_config/processes/happy.nf
+++ b/utils/scripts/tests/workflow_with_config/processes/happy.nf
@@ -1,0 +1,14 @@
+process HAPPY {
+    container "image:tag"
+
+    input:
+        path x
+    
+    output:
+        path "out"
+    
+    script:
+        """
+        echo ${x}
+        """
+}

--- a/utils/scripts/tests/workflow_with_config/processes/has_comments.nf
+++ b/utils/scripts/tests/workflow_with_config/processes/has_comments.nf
@@ -1,0 +1,19 @@
+process HAS_COMMENTS {
+    // line comment above container directive
+    container "foo:fizz"
+    cpus 1 // inline comment
+
+    /*  BLOCK COMMENT
+        above the input stanza
+     */
+    input:
+        val x
+    
+    output:
+        val "output"
+    
+    script:
+        """
+        echo ${x}
+        """
+}

--- a/utils/scripts/tests/workflow_with_config/processes/multiple.nf
+++ b/utils/scripts/tests/workflow_with_config/processes/multiple.nf
@@ -1,0 +1,27 @@
+process FOO {
+    container "foo:fizz"
+    input:
+        val x
+    
+    output:
+        val y
+
+    script:
+        """
+        echo foo
+        """
+}
+
+process BAR {
+    container "bar:buzz"
+    input:
+        val x
+    
+    output:
+        val y
+    
+    script:
+        """
+        echo bar
+        """
+}

--- a/utils/scripts/tests/workflow_with_config/processes/no_container.nf
+++ b/utils/scripts/tests/workflow_with_config/processes/no_container.nf
@@ -1,0 +1,12 @@
+process NO_CONTAINER {
+    input:
+        path x
+    
+    output:
+        path "out"
+    
+    script:
+        """
+        echo ${x}
+        """
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. nf-core recently changed the way they specify the registry (as a docker.registry key in nextflow.config) and using the namespace and image name only in the process blocks. Changes were made to account for this while creating container manifests and omics.config.
2. Fix an gitignore issue where a module name "build" was ignored in rnaseq workflow causing the test to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
