### PR TITLE
adding find_duplicate_read_sets

### DIFF
--- a/utils/scripts/find_duplicate_read_sets/README.md
+++ b/utils/scripts/find_duplicate_read_sets/README.md
@@ -8,15 +8,15 @@ This script was written to help in the identification of duplicate read sets sto
 
 To run this script, simply identify the sequence store IDs you want to search across in a region, specify the input parameters, and you receive a CSV with the read set sources that share an ETag. 
 
-This script makes a few prerequisits:
+### Prerequisits
 1. Python 3.10 or above is installed along with the AWS SDK for Python (`boto3`)
 2. AWS CLI v2 is installed and configured with a profile with read access to AWS HealthOmics sequence stores
 3. All library dependencies are outlined in the attached `requirements.txt` including the following libraries: `pandas, argparse, boto3`
 4. The sequence store IDs input all exist within the region identified.  If the region and sequence store IDs do not match, an error for `The specified sequence store does not exist`will be generated.
 
-usage: find_duplicate_read_sets.py usage: find_duplicate_read_setst.py [-h] -s SEQUENCESTOREIDS -r REGION [-o OUTPUT] [-p PROFILENAME]
+usage: find_duplicate_read_sets.py usage: find_duplicate_read_setst.py [-h] -s SEQUENCESTOREIDS [-o OUTPUT] [--region REGION] [--pofile PROFILE]
 
-### options:  
+### Options
   &nbsp;&nbsp;-h, --help  
 
   &nbsp;&nbsp;-s SEQUENCESTOREIDS, -seq-store-ids INPUT  
@@ -33,14 +33,14 @@ usage: find_duplicate_read_sets.py usage: find_duplicate_read_setst.py [-h] -s S
 
 ## Usage
 
-#### Single Sequence Store:
+#### Single Sequence Store
 
 To identify duplicate read sets within a single sequence store you can pass in a single sequence store ID. 
 
 ``` python
 python find_duplicate_read_sets.py -s "0123456789" -o ~/scratch/duplicate_read_sets.csv
 ```
-#### Multiple Sequence Store:
+#### Multiple Sequence Store
 
 To identify duplicate read sets across multiple sequence store you can pass in a comma separated list of sequence store ID. 
 

--- a/utils/scripts/find_duplicate_read_sets/README.md
+++ b/utils/scripts/find_duplicate_read_sets/README.md
@@ -22,13 +22,13 @@ usage: find_duplicate_read_sets.py usage: find_duplicate_read_setst.py [-h] -s S
   &nbsp;&nbsp;-s SEQUENCESTOREIDS, -seq-store-ids INPUT  
   *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A comma separated list of 1 or more sequence store IDs to check, all in the same region. (e.g. 5068895345,1504776472")*  
 
-  &nbsp;&nbsp;-r REGION, --region REGION  
-  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The region where the sequence stores are in. They must all be in the same region. If this is left unspecified, the code will use the default configured region.*  
-
   &nbsp;&nbsp;-o OUTPUT, --output OUTPUT  
-  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to the current directory.*  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to the current directory.*
 
-  &nbsp;&nbsp;-p PROFILENAME, --profile_name PROFILENAME  
+  &nbsp;&nbsp;--region REGION  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The region where the sequence stores are in. They must all be in the same region. If this is left unspecified, the code will use the default configured region.*    
+
+  &nbsp;&nbsp;--profile PROFILE  
   *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The profile name for boto3 to use if you do not want it to use the default profile configured. Profiles can be created through the AWS CLI using `aws configure` [docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)*    
 
 ## Usage
@@ -38,14 +38,14 @@ usage: find_duplicate_read_sets.py usage: find_duplicate_read_setst.py [-h] -s S
 To identify duplicate read sets within a single sequence store you can pass in a single sequence store ID. 
 
 ``` python
-python find_duplicate_read_sets.py -s "0123456789" -r "us-west-2" -o ~/scratch/duplicate_read_sets.csv
+python find_duplicate_read_sets.py -s "0123456789" -o ~/scratch/duplicate_read_sets.csv
 ```
 #### Multiple Sequence Store:
 
 To identify duplicate read sets across multiple sequence store you can pass in a comma separated list of sequence store ID. 
 
 ``` python
-python find_duplicate_read_sets.py -s "0123456789,6543210987,2134567890" -r "us-west-2" -o ~/scratch/duplicate_read_sets.csv
+python find_duplicate_read_sets.py -s "0123456789,6543210987,2134567890" -o ~/scratch/duplicate_read_sets.csv --region "us-west-2"
 ```
 ## AWS HealthOmics Sequence Store
 For detailed information on how semantic identity works with AWS HealthOmics sequence stores  please visit [ETag calculation and data provenance](https://docs.aws.amazon.com/omics/latest/dev/etags-and-provenance.html)

--- a/utils/scripts/find_duplicate_read_sets/README.md
+++ b/utils/scripts/find_duplicate_read_sets/README.md
@@ -1,0 +1,50 @@
+# AWS HealthOmics Sequence Store Duplicate Read Set Finder script
+
+This is provided AS-IS and is intended to aid in identifying read sets that are duplicate within and across sequence stores in the same region. This is a starting point, feel free to customize as needed to fit your specific requirements.
+
+## find_duplicate_read_sets.py
+
+This script was written to help in the identification of duplicate read sets stored in [AWS HealthOmics sequence stores](https://docs.aws.amazon.com/omics/latest/dev/what-is-service.html). This script relies on [HealthOmics ETags](https://docs.aws.amazon.com/omics/latest/dev/etags-and-provenance.html) which is a hash of the ingested content in a sequence store. 
+
+To run this script, simply identify the sequence store IDs you want to search across in a region, specify the input parameters, and you receive a CSV with the read set sources that share an ETag. 
+
+This script makes a few assumptions:
+1. The boto3 configured by default in your python account or the passed in profile has access to list read sets in the HealthOmics sequence stores identified. 
+2. The sequence store IDs input all exist within the region identified.  If the region and sequence store IDs do not match, an error for `The specified sequence store does not exist`will be generated.
+3. The command has permission to write out a file to the output path specified. 
+
+usage: find_duplicate_read_sets.py usage: find_duplicate_read_setst.py [-h] -s SEQUENCESTOREIDS -r REGION [-o OUTPUT] [-p PROFILENAME]
+
+### options:  
+  &nbsp;&nbsp;-h, --help  
+
+  &nbsp;&nbsp;-s SEQUENCESTOREIDS, --seq_store_ids INPUT  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A comma separated list of 1 or more sequence store IDs to check, all in the same region. (e.g. ""5068895345,1504776472")*  
+
+  &nbsp;&nbsp;-r REGION, --region REGION  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The region where the sequence stores are in. They must all be in the same region.*  
+
+  &nbsp;&nbsp;-o OUTPUT, --output OUTPUT  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to the current directory.*  
+
+  &nbsp;&nbsp;-p PROFILENAME, --profile_name PROFILENAME  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The profile name for boto3 to use if you do not want it to use the default profile configured.*  
+
+## Usage
+
+#### Single Sequence Store:
+
+To identify duplicate read sets within a single sequence store you can pass in a single sequence store ID. 
+
+``` python
+python find_duplicate_read_sets.py -s "0123456789" -r "us-west-2" -o ~/scratch/duplicate_read_sets.csv
+```
+#### Multiple Sequence Store:
+
+To identify duplicate read sets across multiple sequence store you can pass in a comma separated list of sequence store ID. 
+
+``` python
+python find_duplicate_read_sets.py -s "0123456789,6543210987,2134567890" -r "us-west-2" -o ~/scratch/duplicate_read_sets.csv
+```
+## AWS HealthOmics Sequence Store
+For detailed information on how semantic identity works with AWS HealthOmics sequence stores  please visit [ETag calculation and data provenance](https://docs.aws.amazon.com/omics/latest/dev/etags-and-provenance.html)

--- a/utils/scripts/find_duplicate_read_sets/README.md
+++ b/utils/scripts/find_duplicate_read_sets/README.md
@@ -8,27 +8,28 @@ This script was written to help in the identification of duplicate read sets sto
 
 To run this script, simply identify the sequence store IDs you want to search across in a region, specify the input parameters, and you receive a CSV with the read set sources that share an ETag. 
 
-This script makes a few assumptions:
-1. The boto3 configured by default in your python account or the passed in profile has access to list read sets in the HealthOmics sequence stores identified. 
-2. The sequence store IDs input all exist within the region identified.  If the region and sequence store IDs do not match, an error for `The specified sequence store does not exist`will be generated.
-3. The command has permission to write out a file to the output path specified. 
+This script makes a few prerequisits:
+1. Python 3.10 or above is installed along with the AWS SDK for Python (`boto3`)
+2. AWS CLI v2 is installed and configured with a profile with read access to AWS HealthOmics sequence stores
+3. All library dependencies are outlined in the attached `requirements.txt` including the following libraries: `pandas, argparse, boto3`
+4. The sequence store IDs input all exist within the region identified.  If the region and sequence store IDs do not match, an error for `The specified sequence store does not exist`will be generated.
 
 usage: find_duplicate_read_sets.py usage: find_duplicate_read_setst.py [-h] -s SEQUENCESTOREIDS -r REGION [-o OUTPUT] [-p PROFILENAME]
 
 ### options:  
   &nbsp;&nbsp;-h, --help  
 
-  &nbsp;&nbsp;-s SEQUENCESTOREIDS, --seq_store_ids INPUT  
-  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A comma separated list of 1 or more sequence store IDs to check, all in the same region. (e.g. ""5068895345,1504776472")*  
+  &nbsp;&nbsp;-s SEQUENCESTOREIDS, -seq-store-ids INPUT  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A comma separated list of 1 or more sequence store IDs to check, all in the same region. (e.g. 5068895345,1504776472")*  
 
   &nbsp;&nbsp;-r REGION, --region REGION  
-  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The region where the sequence stores are in. They must all be in the same region.*  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The region where the sequence stores are in. They must all be in the same region. If this is left unspecified, the code will use the default configured region.*  
 
   &nbsp;&nbsp;-o OUTPUT, --output OUTPUT  
   *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to the current directory.*  
 
   &nbsp;&nbsp;-p PROFILENAME, --profile_name PROFILENAME  
-  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The profile name for boto3 to use if you do not want it to use the default profile configured.*  
+  *&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(optional) The profile name for boto3 to use if you do not want it to use the default profile configured. Profiles can be created through the AWS CLI using `aws configure` [docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)*    
 
 ## Usage
 

--- a/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
+++ b/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
                         help='(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file \
                         name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to \
                         the current directory.')
-    parser.add_argument('-p', '--profile-name', type=str, 
+    parser.add_argument('-p', '--profile', type=str, 
                         help='(optional) The profile name for boto3 to use if you do not want it to use the default profile configured.')
     
     args = parser.parse_args()
@@ -99,11 +99,11 @@ if __name__ == "__main__":
     # print optional inputs only if they're specified
     if args.region:
         print('Region:', args.region)
-    if args.profile_name:
-        print('Profile Name:', args.profile_name)
+    if args.profile:
+        print('Profile Name:', args.profile)
 
     # setup the boto3 client
-    session = boto3.Session(region_name=args.region, profile_name=args.profile_name)
+    session = boto3.Session(region_name=args.region, profile_name=args.profile)
     omics_client = session.client('omics')
     
     # identify duplicates

--- a/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
+++ b/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
@@ -76,14 +76,14 @@ if __name__ == "__main__":
 
     parser.add_argument('-s', '--seq-store-ids', type=str, required=True, 
                         help='A comma separated list of 1 or more sequence store IDs to check, all in the same region.')
-    parser.add_argument('-r', '--region', type=str, required=False, 
-                        help='(optional) The region where the sequence stores are in. They must all be in the same region. If this is left \
-                        unspecified, the code will use the default configured region.')
     parser.add_argument('-o', '--output', type=str, default='duplicate_read_sets.csv', 
                         help='(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file \
                         name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to \
                         the current directory.')
-    parser.add_argument('-p', '--profile', type=str, 
+    parser.add_argument('--region', type=str, required=False, 
+                        help='(optional) The region where the sequence stores are in. They must all be in the same region. If this is left \
+                        unspecified, the code will use the default configured region.')
+    parser.add_argument('--profile', type=str, 
                         help='(optional) The profile name for boto3 to use if you do not want it to use the default profile configured.')
     
     args = parser.parse_args()
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     if args.region:
         print('Region:', args.region)
     if args.profile:
-        print('Profile Name:', args.profile)
+        print('Profile:', args.profile)
 
     # setup the boto3 client
     session = boto3.Session(region_name=args.region, profile_name=args.profile)

--- a/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
+++ b/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
@@ -1,0 +1,118 @@
+import boto3
+import pandas as pd
+import argparse
+
+
+def find_duplicates(seq_store_ids, omics_client, output_path):
+    """
+    Iterates through all the read sets in all the sequence stores and returns a dataframe with
+    the read sets that share an ETag. This will find duplicates for read sets across sequence 
+    stores.
+
+    """
+
+    # intiate a blank dataframe to store the information for read sets
+    df = pd.DataFrame(columns=['sequence_store_id','read_set_id','name','type','source', 'etag'])
+
+    # setup the paginator to use list read sets
+    paginator = omics_client.get_paginator('list_read_sets')
+
+    # iterate by sequence store.  You can modify this loop if you want to limit to finding duplicates just within the sequence store 
+    for seq_store in seq_store_ids:
+
+        # iterate by page within a read set
+        for page in paginator.paginate(sequenceStoreId=seq_store):
+
+            # get just the read set information
+            for rs in page['readSets']:
+                read_set_id = rs['id']
+                if rs.get('etag',''):
+
+                    # there may be 2 sources if the file type is a FASTQ
+                    etag_source_1 = rs['etag'].get('source1','')
+                    etag_source_2 = rs['etag'].get('source2','')
+                    file_type = rs.get('fileType')
+                    name = rs.get('name')
+
+                    # only log if a etag was found
+                    if etag_source_1:
+                        s1 = {
+                            'sequence_store_id': seq_store,
+                            'read_set_id': read_set_id, 
+                            'name': name,
+                            'type': file_type,
+                            'source': 'source 1', 
+                            'etag': etag_source_1
+                        } 
+                        df = pd.concat([df, pd.DataFrame([s1])])
+                    if etag_source_2:
+                        s2 = {
+                            'sequence_store_id': seq_store,
+                            'read_set_id': read_set_id, 
+                            'name': name,
+                            'type': file_type,
+                            'source': 'source 2', 
+                            'etag': etag_source_2
+                        } 
+                        df = pd.concat([df, pd.DataFrame([s2])])
+
+    # filters to only duplicates based on the etag field
+    filtered_df = df[df.duplicated(subset='etag', keep=False)]
+
+    # sorts for easy identification
+    df_sorted = filtered_df.sort_values(by=['etag','read_set_id'], ascending=True)
+
+    return df_sorted
+
+
+
+# Driver Code
+
+# Decide the two file paths according to your
+# computer system
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-s', '--seq_store_ids', type=str, required=True, dest='seqStoreIds', 
+                        help='A comma separated list of 1 or more sequence store IDs to check, all in the same region.')
+    parser.add_argument('-r', '--region', type=str, required=True, dest='region', 
+                        help='The region where the sequence stores are in. They must all be in the same region.')
+    parser.add_argument('-o', '--output', type=str, default='duplicate_read_sets.csv', dest='output', 
+                        help='(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file \
+                        name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to \
+                        the current directory.')
+    parser.add_argument('-p', '--profile-name', type=str, default='NA', dest='profileName', 
+                        help='(optional) The profile name for boto3 to use if you do not want it to use the default profile configured.')
+    
+    args = parser.parse_args()
+
+    # parse the input sequence store IDs so it's clear what will get passed to the function. 
+    parsed_seq_store_ids = [i.strip() for i in args.seqStoreIds.split(',')]
+    if len(parsed_seq_store_ids) == 0:
+        sys.exit(f'\nERROR: could not parse sequence store ids input: {args.seqStoreIds}')
+
+    print('\nArguments used:\nSequence Store IDs:', str(parsed_seq_store_ids))
+    print('Region:', args.region)
+    print('Output:', args.output)
+
+    # print optional inputs only if they're specified
+    if args.profileName and args.profileName != 'NA':
+        print('Profile Name:', args.profileName,'\n')
+
+    # setup the boto3 client
+    if args.profileName and args.profileName != 'NA':
+        boto3.setup_default_session(profile_name=args.profileName)
+
+    omics_client = boto3.client('omics', region_name=args.region)
+    
+    # identify duplicates
+    df = find_duplicates(parsed_seq_store_ids, omics_client, args.output)
+
+    # counts the duplicates found
+    print(f'Duplicates found: {len(df)}')
+
+    # prints out the read sets. We use 1 since 1 read set can't be a duplicate. 
+    if len(df) > 1:
+        df.to_csv(args.output,index=False)
+

--- a/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
+++ b/utils/scripts/find_duplicate_read_sets/find_duplicate_read_sets.py
@@ -74,37 +74,37 @@ def find_duplicates(seq_store_ids, omics_client, output_path):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-s', '--seq_store_ids', type=str, required=True, dest='seqStoreIds', 
+    parser.add_argument('-s', '--seq-store-ids', type=str, required=True, 
                         help='A comma separated list of 1 or more sequence store IDs to check, all in the same region.')
-    parser.add_argument('-r', '--region', type=str, required=True, dest='region', 
-                        help='The region where the sequence stores are in. They must all be in the same region.')
-    parser.add_argument('-o', '--output', type=str, default='duplicate_read_sets.csv', dest='output', 
+    parser.add_argument('-r', '--region', type=str, required=False, 
+                        help='(optional) The region where the sequence stores are in. They must all be in the same region. If this is left \
+                        unspecified, the code will use the default configured region.')
+    parser.add_argument('-o', '--output', type=str, default='duplicate_read_sets.csv', 
                         help='(optional) The path and file name for the output csv file containing all the duplicate read sets. Include the file \
                         name and prefix (e.g. "~/path/to/out/duplicates.csv"). The default file name is duplicate_read_sets.csv and will write to \
                         the current directory.')
-    parser.add_argument('-p', '--profile-name', type=str, default='NA', dest='profileName', 
+    parser.add_argument('-p', '--profile-name', type=str, 
                         help='(optional) The profile name for boto3 to use if you do not want it to use the default profile configured.')
     
     args = parser.parse_args()
 
     # parse the input sequence store IDs so it's clear what will get passed to the function. 
-    parsed_seq_store_ids = [i.strip() for i in args.seqStoreIds.split(',')]
+    parsed_seq_store_ids = [i.strip() for i in args.seq_store_ids.split(',')]
     if len(parsed_seq_store_ids) == 0:
         sys.exit(f'\nERROR: could not parse sequence store ids input: {args.seqStoreIds}')
 
     print('\nArguments used:\nSequence Store IDs:', str(parsed_seq_store_ids))
-    print('Region:', args.region)
+    
     print('Output:', args.output)
-
     # print optional inputs only if they're specified
-    if args.profileName and args.profileName != 'NA':
-        print('Profile Name:', args.profileName,'\n')
+    if args.region:
+        print('Region:', args.region)
+    if args.profile_name:
+        print('Profile Name:', args.profile_name)
 
     # setup the boto3 client
-    if args.profileName and args.profileName != 'NA':
-        boto3.setup_default_session(profile_name=args.profileName)
-
-    omics_client = boto3.client('omics', region_name=args.region)
+    session = boto3.Session(region_name=args.region, profile_name=args.profile_name)
+    omics_client = session.client('omics')
     
     # identify duplicates
     df = find_duplicates(parsed_seq_store_ids, omics_client, args.output)

--- a/utils/scripts/find_duplicate_read_sets/requirements.txt
+++ b/utils/scripts/find_duplicate_read_sets/requirements.txt
@@ -1,0 +1,3 @@
+pandas>=2.2.1
+argparse>=1.1
+boto3>=1.34.59


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This adds a utility that identifies duplicate read sets based on the ETag


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
