### PR TITLE
Fix HISAT2_ALIGN to handle index files with trailing characters, e.g. ".ht2l" (l for Large)

### DIFF
--- a/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/align/main.nf
+++ b/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/align/main.nf
@@ -36,7 +36,7 @@ process HISAT2_ALIGN {
     if (meta.single_end) {
         def unaligned = params.save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ''
         """
-        INDEX=`find -L ./ -name "*.1.ht2" | sed 's/\\.1.ht2\$//'`
+        INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
         hisat2 \\
             -x \$INDEX \\
             -U $reads \\
@@ -58,7 +58,7 @@ process HISAT2_ALIGN {
     } else {
         def unaligned = params.save_unaligned ? "--un-conc-gz ${prefix}.unmapped.fastq.gz" : ''
         """
-        INDEX=`find -L ./ -name "*.1.ht2" | sed 's/\\.1.ht2\$//'`
+        INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
         hisat2 \\
             -x \$INDEX \\
             -1 ${reads[0]} \\


### PR DESCRIPTION

*Description of changes:*

On:

```bash
*/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/align/main.nf
```
Changed both occurrences of the following:
```bash
INDEX=`find -L ./ -name "*.1.ht2" | sed 's/\\.1.ht2\$//'`
```
To:
```bash
INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
```
Effect:

Correctly extend `find`'s pattern match to capture both the standard `*.ht2` named index files, as well as `*.ht2l` large genome index files e.g. Triticum Aestivum (genome from: ensembl/release-43/Triticum_aestivum.IWGSC.dna_sm.toplevel.fa.gz)


