### PR TITLE
 Fixed hisat2/align/main.nf: perl script manipulation via sed replacement in HISAT2_ALIGN/main.nf to set /tmp to ./tmp

### DIFF
--- a/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/align/main.nf
+++ b/example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/align/main.nf
@@ -36,6 +36,10 @@ process HISAT2_ALIGN {
     if (meta.single_end) {
         def unaligned = params.save_unaligned ? "--un-gz ${prefix}.unmapped.fastq.gz" : ''
         """
+        mkdir -p "./tmp"
+        chmod 700 "./tmp"
+        ls "./tmp"
+        sed -i 's|temp_dir = "/tmp";|temp_dir = "./tmp";|g' /usr/local/bin/hisat2
         INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
         hisat2 \\
             -x \$INDEX \\
@@ -58,6 +62,10 @@ process HISAT2_ALIGN {
     } else {
         def unaligned = params.save_unaligned ? "--un-conc-gz ${prefix}.unmapped.fastq.gz" : ''
         """
+        mkdir -p "./tmp"
+        chmod 700 "./tmp"
+        ls "./tmp"
+        sed -i 's|temp_dir = "/tmp";|temp_dir = "./tmp";|g' /usr/local/bin/hisat2
         INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
         hisat2 \\
             -x \$INDEX \\


### PR DESCRIPTION
**Description of changes:**

Configured perl wrappers that issue the Hisat2 program, via sed replacements in: 

```bash
example-workflows/nf-core/workflows/rnaseq/modules/nf-core/hisat2/align/main.nf
```

From both instances of: 
```groovy
        """
        INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
        hisat2 \\
```
To: 
```groovy
        """
        mkdir -p "./tmp"
        chmod 700 "./tmp"
        ls "./tmp"
        sed -i 's|temp_dir = "/tmp";|temp_dir = "./tmp";|g' /usr/local/bin/hisat2
        INDEX=`find -L ./ -name "*.1.ht2*" | sed 's/\\.1.ht2.*\$//'`
        hisat2 \\
```


**Effect:**
Re-configuring default: 
From: 
```perl
/tmp 
```
To:
```perl
./tmp.
```
Since, `./tmp` has more disk capacity (`aws omics run --storage-capacity <num>`) than `/tmp` (~20-40 GiB) ⇒ run failure case space << before.

Kudos:
@markjschreiber 

