### PR TITLE
Add dynamic storage parameter

### DIFF
--- a/example-workflows/_conf/default.ini
+++ b/example-workflows/_conf/default.ini
@@ -21,3 +21,11 @@
 # absolute path ('~' expansion allowed) to the parent folder for omx-ecr-helper
 # this is an AWS CDK application that is used to retrieve or build container images
 # omx_ecr_helper = ~/amazon-omics-tutorials/utils/cdk/omx-ecr-helper
+
+# run storage type for the run
+# possible values are STATIC or DYNAMIC
+# run_storage_type=STATIC
+
+# static run storage capacity in GiB.
+# value won't be used for dynamic run storage
+# run_storage_capacity=1200

--- a/example-workflows/_scripts/builder/__init__.py
+++ b/example-workflows/_scripts/builder/__init__.py
@@ -27,7 +27,9 @@ CONFIG_DEFAULTS = {
     'output_uri': None,
     'workflow_role_name': None,
     'ecr_registry': None,
-    'omx_ecr_helper': '~/amazon-omics-tutorials/utils/cdk/omx-ecr-helper'
+    'omx_ecr_helper': '~/amazon-omics-tutorials/utils/cdk/omx-ecr-helper',
+    'run_storage_type': 'STATIC',
+    'run_storage_capacity': '1200'
 }
 
 class Builder:
@@ -341,6 +343,9 @@ class Builder:
         staging_uri = cfg['staging_uri']
         output_uri = cfg['output_uri']
         account_id = cfg['account_id']
+        run_storage_type = cfg['run_storage_type']
+        run_storage_capacity_string = cfg['run_storage_capacity']
+        run_storage_capacity = int(run_storage_capacity_string)
 
         with open(f'workflows/{workflow_name}/test.parameters.json', 'r') as f:
             test_parameters = f.read()
@@ -366,7 +371,9 @@ class Builder:
             name=f"test: {workflow_name}",
             roleArn=workflow_role_arn,
             outputUri=output_uri,
-            parameters=test_parameters
+            parameters=test_parameters,
+            storageCapacity=run_storage_capacity,
+            storageType=run_storage_type
         )
 
         # write out final test parameters for tracking

--- a/example-workflows/_scripts/requirements.txt
+++ b/example-workflows/_scripts/requirements.txt
@@ -1,3 +1,3 @@
 python-on-whales==0.60.0
-PyYAML==6.0
-boto3>=1.26.84
+PyYAML==6.0.2
+boto3>=1.35.91


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds an additional configuration parameter to run the workflows with a different run storage configuration:
- adds variable run storage size for STATIC storage
- adds dynamic run storage option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
