### PR TITLE
Add annotation-database project and GFF3-to-Iceberg HealthOmics workflow

### DIFF
--- a/annotation-database/.gitignore
+++ b/annotation-database/.gitignore
@@ -1,0 +1,7 @@
+venv/
+__pycache__/
+*.pyc
+.DS_Store
+*.egg-info/
+dist/
+build/

--- a/annotation-database/README.md
+++ b/annotation-database/README.md
@@ -1,0 +1,166 @@
+# Creating and Loading Iceberg Tables with GFF3 Annotation Data
+
+This project demonstrates how to use PyIceberg to connect to an AWS S3Tables catalog, create Iceberg tables for storing genomic annotation data, and load GFF3 files into these tables.
+
+## Prerequisites
+
+- AWS account with appropriate permissions
+- Python 3.8+
+- AWS credentials configured (CLI, environment variables, IAM role, etc.)
+
+## Installation
+
+```bash
+python -m venv venv
+./setup.sh
+
+# Or manually:
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Update the `--bucket-arn` argument with your S3Tables bucket ARN:
+
+```
+arn:aws:s3tables:us-east-1:YOUR_ACCOUNT_ID:bucket/YOUR_BUCKET_NAME
+```
+
+## Project Structure
+
+- `utils.py` — Utility functions for S3Tables and Iceberg operations
+- `schema_1.py` — Normalized schema: features, sources, feature_relationships
+- `schema_2.py` — Denormalized schema: single genomic_annotations table
+- `metadata_schema.py` — Schema for GFF3 file-level directives and pragmas
+- `load_gff3_schema1.py` — Load GFF3 files into Schema 1 tables
+- `load_gff3_schema2.py` — Load GFF3 files into Schema 2 table
+- `describe_tables.py` — Describe existing Iceberg tables
+- `drop_tables.py` — Drop tables from a namespace
+
+## Usage
+
+### Creating Tables
+
+```bash
+python schema_1.py --bucket-arn <bucket_arn>  # Creates tables in namespace annotation_db
+python schema_2.py --bucket-arn <bucket_arn>  # Creates tables in namespace annotation_db_2
+```
+
+### Loading GFF3 Data
+
+```bash
+# Load into Schema 1 (normalized)
+python load_gff3_schema1.py --bucket-arn <bucket_arn> path/to/annotations.gff3.gz ...
+
+# Load into Schema 2 (denormalized)
+python load_gff3_schema2.py --bucket-arn <bucket_arn> path/to/annotations.gff3.gz ...
+
+# Load from S3
+python load_gff3_schema1.py --bucket-arn <bucket_arn> s3://bucket/annotations.gff3.gz
+```
+
+### Describing Tables
+
+```bash
+python describe_tables.py --bucket-arn <bucket_arn>
+```
+
+### Dropping Tables
+
+```bash
+python drop_tables.py --bucket-arn <bucket_arn> --namespace annotation_db --confirm
+```
+
+## Schema Designs
+
+### Schema 1 — Normalized (`schema_1.py`)
+
+Three tables in namespace `annotation_db`:
+
+1. **features** — Core annotation features
+   - `feature_id` (String, primary key) — GFF3 `ID` attribute
+   - `seqid` (String) — Chromosome / landmark
+   - `source` (String) — Annotation source program
+   - `type` (String) — Feature type / SO term (gene, mRNA, exon, CDS, etc.)
+   - `start` (Long) — Start position, 1-based inclusive
+   - `end` (Long) — End position, 1-based inclusive
+   - `score` (Double) — Score value
+   - `strand` (String) — +, -, ., or ?
+   - `phase` (String) — CDS phase: 0, 1, or 2
+   - `name` (String) — GFF3 `Name` attribute
+   - `dbxref` (String) — Database cross-references
+   - `ontology_term` (String) — Ontology terms
+   - `is_circular` (Boolean) — Circular feature flag
+   - `attributes` (Map<String, String>) — All remaining GFF3 attributes
+   - Partitioned by: `seqid` + `type_bucket` (128 buckets)
+   - Sorted by: `start` (ascending)
+
+2. **sources** — Distinct annotation sources
+   - `source_name` (String)
+   - `description` (String)
+
+3. **feature_relationships** — Parent-child hierarchy
+   - `child_id` (String) — Child feature ID
+   - `parent_id` (String) — Parent feature ID
+   - `seqid` (String) — Chromosome (for partition-aligned joins)
+   - `child_type` (String) — e.g., exon, CDS
+   - `parent_type` (String) — e.g., gene, mRNA
+   - Partitioned by: `seqid`
+   - Sorted by: `parent_id` (ascending)
+
+### Schema 2 — Denormalized (`schema_2.py`)
+
+Single table in namespace `annotation_db_2`:
+
+1. **genomic_annotations** — All feature data with embedded parent references
+   - Same columns as Schema 1 features, plus:
+   - `parent_ids` (List<String>) — GFF3 `Parent` attribute as a list
+   - Partitioned by: `seqid` + `type_bucket` (128 buckets)
+   - Sorted by: `seqid` and `start` (ascending)
+
+## GFF3 Parsing Details
+
+- **URL decoding**: GFF3 requires percent-encoding for special characters; the parser handles this automatically
+- **Reserved attributes**: `ID`, `Name`, `Parent`, `Dbxref`, `Ontology_term`, `Is_circular` are extracted into dedicated columns
+- **Remaining attributes**: Stored in a `Map<String, String>` column
+- **Multi-value Parent**: `Parent=mRNA00001,mRNA00002` produces multiple relationship rows (Schema 1) or a list (Schema 2)
+- **FASTA section**: The parser stops at `>` lines (inline FASTA sequences are skipped)
+- **Directives**: `##` header lines are logged; use `metadata_schema.py` to persist them
+
+## Performance Considerations
+
+- **Schema 1**: Normalized — good for data integrity, enables tree traversal queries via the relationship table, requires joins
+- **Schema 2**: Denormalized — fastest for region-based queries, parent info embedded, some source duplication
+
+## Required AWS Permissions
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3tables:CreateTable",
+                "s3tables:GetTable",
+                "s3tables:ListNamespaces",
+                "s3tables:CreateNamespace",
+                "s3tables:ListTables",
+                "s3tables:DeleteTable",
+                "s3tables:PutTableData",
+                "s3tables:GetTableData"
+            ],
+            "Resource": [
+                "arn:aws:s3tables:*:*:bucket/*"
+            ]
+        }
+    ]
+}
+```
+
+## Resources
+
+- [GFF3 Specification](https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md)
+- [AWS S3Tables Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-open-source.html)
+- [PyIceberg Documentation](https://py.iceberg.apache.org/)

--- a/annotation-database/describe_tables.py
+++ b/annotation-database/describe_tables.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Script to describe Iceberg tables in all namespaces using PyIceberg and AWS S3Tables.
+"""
+import json
+import traceback
+from typing import Dict, List, Any
+from pyiceberg.catalog import Catalog
+from pyiceberg.table import Table
+from utils import load_s3_tables_catalog
+
+
+def describe_table(table: Table, identifier: tuple) -> Dict[str, Any]:
+    """
+    Generate a detailed description of an Iceberg table.
+    
+    Args:
+        table: PyIceberg Table object
+        identifier: Tuple containing namespace and table name
+        
+    Returns:
+        Dictionary containing table details
+    """
+    table_info = {
+        "name": identifier,
+        "location": table.location(),
+        "properties": table.properties,
+        "schema": [],
+        "current_snapshot_id": table.metadata.current_snapshot_id,
+        "format_version": table.metadata.format_version,
+    }
+    
+    # Add schema fields
+    for field in table.schema().fields:
+        field_info = {
+            "id": field.field_id,
+            "name": field.name,
+            "type": str(field.field_type),
+            "required": field.required,
+        }
+        if field.doc:
+            field_info["doc"] = field.doc
+        table_info["schema"].append(field_info)
+    
+    # Add partition information if available
+    if table.spec() and table.spec().fields:
+        table_info["partition_spec"] = []
+        for field in table.spec().fields:
+            table_info["partition_spec"].append({
+                "source_id": field.source_id,
+                "field_id": field.field_id,
+                "name": field.name,
+                "transform": str(field.transform),
+            })
+    
+    # Add sort order if available
+    if table.sort_order() and table.sort_order().fields:
+        table_info["sort_order"] = []
+        for field in table.sort_order().fields:
+            table_info["sort_order"].append({
+                "source_id": field.source_id,
+                "transform": str(field.transform),
+                "direction": str(field.direction),
+                "null_order": str(field.null_order),
+            })
+    
+    # Add snapshot information if available
+    if table.metadata.snapshots:
+        table_info["snapshots"] = []
+        for snapshot in table.metadata.snapshots:
+            try:
+                # Create basic snapshot info with guaranteed attributes
+                snapshot_info = {
+                    "snapshot_id": snapshot.snapshot_id,
+                    "timestamp_ms": snapshot.timestamp_ms,
+                    "summary": {},
+                }
+                
+                # Handle summary which could be a tuple, dict, or other type
+                if hasattr(snapshot, 'summary') and snapshot.summary is not None:
+                    if isinstance(snapshot.summary, dict):
+                        # If it's a dictionary, convert values to strings
+                        for key, value in snapshot.summary.items():
+                            snapshot_info["summary"][key] = str(value)
+                    elif isinstance(snapshot.summary, (tuple, list)):
+                        # If it's a tuple or list, convert to a list of strings
+                        snapshot_info["summary"]["values"] = [str(item) for item in snapshot.summary]
+                    else:
+                        # For any other type, just use string representation
+                        snapshot_info["summary"]["value"] = str(snapshot.summary)
+                
+                # Handle manifest_list safely
+                if hasattr(snapshot, 'manifest_list') and snapshot.manifest_list:
+                    snapshot_info["manifest_list"] = str(snapshot.manifest_list)
+                    
+                table_info["snapshots"].append(snapshot_info)
+            except Exception as e:
+                # If there's an error processing a snapshot, add a placeholder with error info
+                table_info["snapshots"].append({
+                    "snapshot_id": getattr(snapshot, "snapshot_id", "unknown"),
+                    "error": f"Error processing snapshot: {str(e)}"
+                })
+    
+    return table_info
+
+
+def list_tables(catalog: Catalog, namespace: str) -> List[str]:
+    """
+    List all tables in a namespace.
+    
+    Args:
+        catalog: PyIceberg Catalog object
+        namespace: Namespace to list tables from
+        
+    Returns:
+        List of table identifiers
+    """
+    try:
+        return catalog.list_tables(namespace)
+    except Exception as e:
+        print(f"Error listing tables in namespace {namespace}: {str(e)}")
+        return []
+
+
+def describe_tables_in_namespace(catalog: Catalog, namespace: str) -> None:
+    """
+    Describe all tables in a given namespace.
+    
+    Args:
+        catalog: PyIceberg Catalog object
+        namespace: Namespace to describe tables from
+    """
+    # List tables in the namespace
+    print(f"\nListing tables in namespace: {namespace}")
+    table_identifiers = list_tables(catalog, namespace)
+    
+    if not table_identifiers:
+        print(f"No tables found in namespace {namespace}")
+        return
+    
+    print(f"Found {len(table_identifiers)} tables in namespace {namespace}:")
+    for identifier in table_identifiers:
+        print(f"  - {identifier}")
+    
+    # Describe each table
+    print("\nTable Details:")
+    for identifier in table_identifiers:
+        try:
+            table = catalog.load_table(identifier)
+            table_info = describe_table(table, identifier)
+            
+            print(f"\n{'-' * 80}")
+            print(f"Table: {identifier}")
+            print(f"{'-' * 80}")
+            print(f"Location: {table_info['location']}")
+            print(f"Format Version: {table_info['format_version']}")
+            
+            print("\nSchema:")
+            for field in table_info['schema']:
+                required = "required" if field['required'] else "optional"
+                print(f"  - {field['name']} ({field['type']}, {required}, id={field['id']})")
+                if 'doc' in field:
+                    print(f"    Doc: {field['doc']}")
+            
+            if 'partition_spec' in table_info:
+                print("\nPartition Spec:")
+                for partition in table_info['partition_spec']:
+                    print(f"  - {partition['name']} ({partition['transform']})")
+            
+            if 'sort_order' in table_info:
+                print("\nSort Order:")
+                for sort_field in table_info['sort_order']:
+                    print(f"  - {sort_field['transform']} ({sort_field['direction']}, {sort_field['null_order']})")
+            
+            if 'snapshots' in table_info and table_info['snapshots']:
+                for snapshot in table_info['snapshots']:
+                    if 'error' in snapshot:
+                        print(f"  - Error: {snapshot['error']}")
+                        continue
+                        
+                    print(f"  - ID: {snapshot['snapshot_id']}, Time: {snapshot['timestamp_ms']}")
+                    if snapshot['summary']:
+                        try:
+                            print(f"    Summary: {json.dumps(snapshot['summary'])}")
+                        except Exception:
+                            print(f"    Summary: {snapshot['summary']}")
+            
+            # Print record count if available in the latest snapshot
+            if 'snapshots' in table_info and table_info['snapshots']:
+                try:
+                    latest_snapshot = table_info['snapshots'][-1]
+                    if ('summary' in latest_snapshot and 
+                        latest_snapshot['summary'] and 
+                        'total-records' in latest_snapshot['summary']):
+                        print(f"\nRecord Count: {latest_snapshot['summary']['total-records']}")
+                except Exception:
+                    pass  # Skip record count if there's an issue
+            
+        except Exception as e:
+            print(f"Error describing table {identifier}: {str(e)}")
+            # Uncomment for debugging
+            # traceback.print_exc()
+
+
+def main():
+    import argparse
+    
+    parser = argparse.ArgumentParser(description='Describe all Iceberg tables in S3Tables catalog')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    args = parser.parse_args()
+    
+    # Load the S3Tables catalog
+    print(f"Connecting to S3Tables catalog with bucket ARN: {args.bucket_arn}")
+    catalog = load_s3_tables_catalog(args.bucket_arn)
+    
+    # List all namespaces
+    print("Listing all namespaces:")
+    namespaces = catalog.list_namespaces()
+    
+    if not namespaces:
+        print("No namespaces found in the catalog")
+        return
+        
+    for ns in namespaces:
+        print(f"  - {ns}")
+        
+    # Iterate through each namespace and describe all tables
+    for namespace in namespaces:
+        # Handle both cases: when namespace is a tuple/list or when it's already a string
+        if isinstance(namespace, (list, tuple)):
+            namespace_str = ".".join(namespace)  # Convert namespace tuple to string
+        else:
+            namespace_str = str(namespace)  # Ensure it's a string
+            
+        print(f"\n{'=' * 80}")
+        print(f"Namespace: {namespace_str}")
+        print(f"{'=' * 80}")
+        describe_tables_in_namespace(catalog, namespace_str)
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation-database/drop_tables.py
+++ b/annotation-database/drop_tables.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Drop (purge) all tables in a specified namespace for an AWS S3Tables catalog.
+
+Usage:
+    python drop_tables.py --bucket-arn <bucket_arn> --namespace <namespace> [--confirm]
+
+Arguments:
+    --bucket-arn: The ARN of the S3Tables bucket
+    --namespace: The namespace containing tables to drop
+    --confirm: If provided, tables will be dropped without confirmation prompts
+"""
+
+import argparse
+import sys
+from typing import List
+
+from utils import load_s3_tables_catalog
+
+
+def list_tables(bucket_arn: str, namespace: str) -> List[str]:
+    """
+    List all tables in the specified namespace.
+    
+    Args:
+        bucket_arn: The ARN of the S3Tables bucket
+        namespace: The namespace to list tables from
+        
+    Returns:
+        List of table names in the namespace
+    """
+    catalog = load_s3_tables_catalog(bucket_arn)
+    
+    # Check if namespace exists
+    namespaces = catalog.list_namespaces()
+    namespace_exists = False
+    
+    for ns in namespaces:
+        # Handle both string and tuple namespaces
+        if isinstance(ns, tuple) and len(ns) == 1 and ns[0] == namespace:
+            namespace_exists = True
+            break
+        elif ns == namespace:
+            namespace_exists = True
+            break
+    
+    if not namespace_exists:
+        print(f"Namespace '{namespace}' does not exist.")
+        return []
+    
+    # List tables in the namespace
+    tables = catalog.list_tables(namespace)
+    return [table[1] for table in tables]  # Extract table names from (namespace, table_name) tuples
+
+
+def drop_tables(bucket_arn: str, namespace: str, confirm: bool = False) -> None:
+    """
+    Drop all tables in the specified namespace.
+    
+    Args:
+        bucket_arn: The ARN of the S3Tables bucket
+        namespace: The namespace containing tables to drop
+        confirm: If True, tables will be dropped without confirmation prompts
+    """
+    catalog = load_s3_tables_catalog(bucket_arn)
+    
+    # Get list of tables
+    tables = list_tables(bucket_arn, namespace)
+    
+    if not tables:
+        print(f"No tables found in namespace '{namespace}'.")
+        return
+    
+    print(f"Found {len(tables)} tables in namespace '{namespace}':")
+    for table in tables:
+        print(f"  - {namespace}.{table}")
+    
+    # Confirm before dropping tables
+    if not confirm:
+        response = input(f"\nAre you sure you want to drop all {len(tables)} tables? (y/N): ")
+        if response.lower() != 'y':
+            print("Operation cancelled.")
+            return
+    
+    # Drop each table
+    for table in tables:
+        try:
+            full_table_name = f"{namespace}.{table}"
+            # Use purge_table instead of drop_table for S3Tables
+            if hasattr(catalog, 'purge_table'):
+                catalog.purge_table(full_table_name)
+            else:
+                # Fall back to drop_table if purge_table is not available
+                catalog.drop_table(full_table_name)
+            print(f"Dropped table: {full_table_name}")
+        except Exception as e:
+            print(f"Error dropping table {full_table_name}: {str(e)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Drop all tables in a specified namespace")
+    parser.add_argument("--bucket-arn", required=True, help="ARN of the S3Tables bucket")
+    parser.add_argument("--namespace", required=True, help="Namespace containing tables to drop")
+    parser.add_argument("--confirm", action="store_true", help="Drop tables without confirmation")
+    
+    args = parser.parse_args()
+    
+    try:
+        drop_tables(args.bucket_arn, args.namespace, args.confirm)
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation-database/load_gff3_schema1.py
+++ b/annotation-database/load_gff3_schema1.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+Load GFF3 files into the annotation_db tables created by schema_1.py.
+
+Parses GFF3 files and loads data into three Iceberg tables:
+  - features
+  - sources
+  - feature_relationships
+"""
+
+import argparse
+import os
+import sys
+import gzip
+import pyarrow as pa
+from urllib.parse import unquote
+from pyiceberg.exceptions import NoSuchTableError
+from utils import load_s3_tables_catalog, retry_operation
+import boto3
+from io import TextIOWrapper
+
+# Configuration
+NAMESPACE = "annotation_db"
+FEATURES_TABLE = "features"
+SOURCES_TABLE = "sources"
+RELATIONSHIPS_TABLE = "feature_relationships"
+BATCH_SIZE = 100000
+
+
+def parse_s3_uri(s3_uri):
+    """Parse S3 URI and return bucket and key."""
+    if not s3_uri.startswith('s3://'):
+        raise ValueError(f"Invalid S3 URI format: {s3_uri}")
+    s3_parts = s3_uri[5:].split('/', 1)
+    if len(s3_parts) != 2 or not s3_parts[0] or not s3_parts[1]:
+        raise ValueError(f"Invalid S3 URI — missing bucket or key: {s3_uri}")
+    return s3_parts[0], s3_parts[1]
+
+
+def get_tables():
+    """Get the existing tables or fail if they don't exist."""
+    catalog = load_s3_tables_catalog(bucket_arn)
+
+    try:
+        namespaces = [ns[0] for ns in catalog.list_namespaces()]
+        if NAMESPACE not in namespaces:
+            print(f"Error: Namespace '{NAMESPACE}' does not exist.")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error checking namespaces: {e}")
+        sys.exit(1)
+
+    tables = {}
+    for table_name in [FEATURES_TABLE, SOURCES_TABLE, RELATIONSHIPS_TABLE]:
+        table_identifier = f"{NAMESPACE}.{table_name}"
+        try:
+            tables[table_name] = catalog.load_table(table_identifier)
+        except NoSuchTableError:
+            print(f"Error: Table '{table_identifier}' does not exist.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error loading table {table_identifier}: {e}")
+            sys.exit(1)
+
+    return tables
+
+
+def open_gff3_file(file_path):
+    """Open a GFF3 file, handling local files, S3 URIs, and gzip."""
+    if file_path.startswith('s3://'):
+        bucket, key = parse_s3_uri(file_path)
+        s3_client = boto3.client('s3')
+        response = s3_client.get_object(Bucket=bucket, Key=key)
+        if file_path.endswith('.gz'):
+            return TextIOWrapper(gzip.GzipFile(fileobj=response['Body']))
+        else:
+            return TextIOWrapper(response['Body'])
+    else:
+        if file_path.endswith('.gz'):
+            return gzip.open(file_path, 'rt')
+        else:
+            return open(file_path, 'r')
+
+
+# Reserved GFF3 attributes that get extracted into dedicated columns
+RESERVED_ATTRIBUTES = {'ID', 'Name', 'Parent', 'Dbxref', 'Ontology_term', 'Is_circular'}
+
+
+def parse_gff3_attributes(attr_str):
+    """Parse GFF3 column 9 attributes with URL-decoding.
+
+    Returns a dict of all attributes. Reserved keys are included
+    so callers can extract them before storing the remainder.
+    """
+    if attr_str == '.' or not attr_str.strip():
+        return {}
+
+    attrs = {}
+    for item in attr_str.split(';'):
+        item = item.strip()
+        if not item:
+            continue
+        if '=' in item:
+            key, value = item.split('=', 1)
+            attrs[unquote(key)] = unquote(value)
+        else:
+            attrs[unquote(item)] = 'true'
+    return attrs
+
+
+def parse_gff3_header(gff3_file):
+    """Parse GFF3 header directives. Returns (directives, first_data_line).
+
+    directives is a list of (key, value) tuples for ## lines.
+    first_data_line is the first non-comment, non-empty line (or None).
+    """
+    directives = []
+    first_data_line = None
+
+    for line in gff3_file:
+        line = line.rstrip('\n\r')
+        if not line or line.startswith('###'):
+            continue
+        if line.startswith('##'):
+            parts = line[2:].strip().split(None, 1)
+            key = parts[0] if parts else ''
+            value = parts[1] if len(parts) > 1 else ''
+            directives.append((key, value))
+            continue
+        if line.startswith('#'):
+            continue
+        # First data line
+        first_data_line = line
+        break
+
+    return directives, first_data_line
+
+
+def process_gff3_batch(batch_lines):
+    """Process a batch of GFF3 data lines.
+
+    Returns dicts of PyArrow arrays for features and feature_relationships,
+    plus a set of source names encountered.
+    """
+    # Features columns
+    feature_id_list = []
+    seqid_list = []
+    source_list = []
+    type_list = []
+    start_list = []
+    end_list = []
+    score_list = []
+    strand_list = []
+    phase_list = []
+    name_list = []
+    dbxref_list = []
+    ontology_term_list = []
+    is_circular_list = []
+    attributes_list = []
+
+    # Relationships columns
+    rel_child_id_list = []
+    rel_parent_id_list = []
+    rel_seqid_list = []
+    rel_child_type_list = []
+    rel_parent_type_list = []
+
+    # Track sources and parent types for relationship enrichment
+    sources_seen = set()
+    feature_types = {}  # feature_id -> type, built during this batch
+
+    for line in batch_lines:
+        fields = line.split('\t')
+        if len(fields) < 9:
+            print(f"Warning: Skipping malformed GFF3 line (< 9 fields): {line[:80]}")
+            continue
+
+        seqid = unquote(fields[0])
+        source = unquote(fields[1])
+        feat_type = unquote(fields[2])
+
+        try:
+            start = int(fields[3])
+            end = int(fields[4])
+        except ValueError:
+            print(f"Warning: Invalid start/end in GFF3 line: {line[:80]}")
+            continue
+
+        score = None
+        if fields[5] != '.':
+            try:
+                score = float(fields[5])
+            except ValueError:
+                pass
+
+        strand = fields[6] if fields[6] != '.' else None
+        phase = fields[7] if fields[7] != '.' else None
+
+        # Parse attributes
+        attrs = parse_gff3_attributes(fields[8])
+
+        feature_id = attrs.get('ID', f"{seqid}:{feat_type}:{start}-{end}")
+        name = attrs.get('Name')
+        parent_str = attrs.get('Parent')
+        dbxref = attrs.get('Dbxref')
+        ontology_term = attrs.get('Ontology_term')
+        is_circular = attrs.get('Is_circular', '').lower() == 'true' if 'Is_circular' in attrs else None
+
+        # Build remaining attributes map (exclude reserved keys)
+        remaining_attrs = {k: v for k, v in attrs.items() if k not in RESERVED_ATTRIBUTES}
+
+        # Track
+        sources_seen.add(source)
+        feature_types[feature_id] = feat_type
+
+        # Append feature data
+        feature_id_list.append(feature_id)
+        seqid_list.append(seqid)
+        source_list.append(source)
+        type_list.append(feat_type)
+        start_list.append(start)
+        end_list.append(end)
+        score_list.append(score)
+        strand_list.append(strand)
+        phase_list.append(phase)
+        name_list.append(name)
+        dbxref_list.append(dbxref)
+        ontology_term_list.append(ontology_term)
+        is_circular_list.append(is_circular)
+        attributes_list.append(remaining_attrs)
+
+        # Build relationship rows (one per parent)
+        if parent_str:
+            parent_ids = [p.strip() for p in parent_str.split(',')]
+            for pid in parent_ids:
+                rel_child_id_list.append(feature_id)
+                rel_parent_id_list.append(pid)
+                rel_seqid_list.append(seqid)
+                rel_child_type_list.append(feat_type)
+                rel_parent_type_list.append(feature_types.get(pid))
+
+    # Convert to PyArrow arrays
+    features_arrays = {
+        'feature_id': pa.array(feature_id_list, type=pa.string()),
+        'seqid': pa.array(seqid_list, type=pa.string()),
+        'source': pa.array(source_list, type=pa.string()),
+        'type': pa.array(type_list, type=pa.string()),
+        'start': pa.array(start_list, type=pa.int64()),
+        'end': pa.array(end_list, type=pa.int64()),
+        'score': pa.array(score_list, type=pa.float64()),
+        'strand': pa.array(strand_list, type=pa.string()),
+        'phase': pa.array(phase_list, type=pa.string()),
+        'name': pa.array(name_list, type=pa.string()),
+        'dbxref': pa.array(dbxref_list, type=pa.string()),
+        'ontology_term': pa.array(ontology_term_list, type=pa.string()),
+        'is_circular': pa.array(is_circular_list, type=pa.bool_()),
+        'attributes': pa.array(
+            [{str(k): str(v) for k, v in d.items()} for d in attributes_list],
+            type=pa.map_(pa.string(), pa.string())),
+    }
+
+    relationships_arrays = None
+    if rel_child_id_list:
+        relationships_arrays = {
+            'child_id': pa.array(rel_child_id_list, type=pa.string()),
+            'parent_id': pa.array(rel_parent_id_list, type=pa.string()),
+            'seqid': pa.array(rel_seqid_list, type=pa.string()),
+            'child_type': pa.array(rel_child_type_list, type=pa.string()),
+            'parent_type': pa.array(rel_parent_type_list, type=pa.string()),
+        }
+
+    return features_arrays, relationships_arrays, sources_seen
+
+
+def write_to_iceberg(table, data_arrays, pyarrow_schema, table_name):
+    """Write data arrays to an Iceberg table with retry logic."""
+    columns = [data_arrays[field.name] for field in pyarrow_schema]
+    arrow_table = pa.Table.from_arrays(columns, schema=pyarrow_schema)
+
+    print(f"Writing {len(arrow_table)} rows to {NAMESPACE}.{table_name}...")
+
+    def is_commit_failed(e):
+        return "CommitFailedException" in str(e) and "branch main has changed" in str(e)
+
+    retry_operation(
+        table.append,
+        arrow_table,
+        max_retries=5,
+        retry_condition=is_commit_failed,
+    )
+    print(f"Successfully wrote {len(arrow_table)} rows to {NAMESPACE}.{table_name}")
+
+
+def process_gff3_file(gff3_path, tables=None, pyarrow_schemas=None):
+    """Process a GFF3 file in batches and write to Iceberg tables."""
+    print(f"Processing GFF3 file: {gff3_path}")
+
+    all_sources = set()
+
+    with open_gff3_file(gff3_path) as gff3_file:
+        directives, first_line = parse_gff3_header(gff3_file)
+
+        # Log directives
+        for key, value in directives:
+            print(f"  Directive: ##{key} {value}")
+
+        # Process data lines in batches
+        batch_lines = []
+        if first_line:
+            batch_lines.append(first_line)
+
+        records_processed = 0
+
+        for line in gff3_file:
+            line = line.rstrip('\n\r')
+            if not line or line.startswith('#'):
+                continue
+            # FASTA section terminates GFF3 features
+            if line.startswith('>'):
+                break
+
+            batch_lines.append(line)
+
+            if len(batch_lines) >= BATCH_SIZE:
+                feat_arrays, rel_arrays, sources = process_gff3_batch(batch_lines)
+                all_sources.update(sources)
+
+                if tables and pyarrow_schemas:
+                    write_to_iceberg(tables[FEATURES_TABLE], feat_arrays,
+                                     pyarrow_schemas[FEATURES_TABLE], FEATURES_TABLE)
+                    if rel_arrays:
+                        write_to_iceberg(tables[RELATIONSHIPS_TABLE], rel_arrays,
+                                         pyarrow_schemas[RELATIONSHIPS_TABLE], RELATIONSHIPS_TABLE)
+
+                records_processed += len(batch_lines)
+                print(f"Processed {records_processed} records so far...")
+                batch_lines = []
+
+        # Remaining records
+        if batch_lines:
+            feat_arrays, rel_arrays, sources = process_gff3_batch(batch_lines)
+            all_sources.update(sources)
+
+            if tables and pyarrow_schemas:
+                write_to_iceberg(tables[FEATURES_TABLE], feat_arrays,
+                                 pyarrow_schemas[FEATURES_TABLE], FEATURES_TABLE)
+                if rel_arrays:
+                    write_to_iceberg(tables[RELATIONSHIPS_TABLE], rel_arrays,
+                                     pyarrow_schemas[RELATIONSHIPS_TABLE], RELATIONSHIPS_TABLE)
+
+            records_processed += len(batch_lines)
+
+        # Write sources
+        if all_sources and tables and pyarrow_schemas:
+            sources_arrays = {
+                'source_name': pa.array(sorted(all_sources), type=pa.string()),
+                'description': pa.array([None] * len(all_sources), type=pa.string()),
+            }
+            write_to_iceberg(tables[SOURCES_TABLE], sources_arrays,
+                             pyarrow_schemas[SOURCES_TABLE], SOURCES_TABLE)
+
+        print(f"Processed {records_processed} records total from {gff3_path}")
+
+
+def main():
+    global bucket_arn, NAMESPACE, BATCH_SIZE
+
+    parser = argparse.ArgumentParser(description='Load GFF3 files into Iceberg tables (Schema 1)')
+    parser.add_argument('gff3_files', nargs='+', help='GFF3 file paths to load (local or s3://)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    parser.add_argument('--namespace', default=NAMESPACE, help=f'Iceberg namespace (default: {NAMESPACE})')
+    parser.add_argument('--batch-size', type=int, default=BATCH_SIZE,
+                        help=f'Records per batch (default: {BATCH_SIZE})')
+    args = parser.parse_args()
+
+    bucket_arn = args.bucket_arn
+    NAMESPACE = args.namespace
+    BATCH_SIZE = args.batch_size
+
+    print("Getting tables...")
+    tables = get_tables()
+    pyarrow_schemas = {
+        table_name: table.schema().as_arrow()
+        for table_name, table in tables.items()
+    }
+
+    for gff3_file in args.gff3_files:
+        file_exists = True
+        if gff3_file.startswith('s3://'):
+            try:
+                bucket, key = parse_s3_uri(gff3_file)
+                s3_client = boto3.client('s3')
+                s3_client.head_object(Bucket=bucket, Key=key)
+            except Exception as e:
+                file_exists = False
+                print(f"Error: S3 file not found: {gff3_file} — {e}")
+        else:
+            file_exists = os.path.exists(gff3_file)
+            if not file_exists:
+                print(f"Error: Local file not found: {gff3_file}")
+
+        if not file_exists:
+            continue
+
+        try:
+            process_gff3_file(gff3_file, tables, pyarrow_schemas)
+        except Exception as e:
+            print(f"Error processing file {gff3_file}: {e}")
+            import traceback
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation-database/load_gff3_schema2.py
+++ b/annotation-database/load_gff3_schema2.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Load GFF3 files into the annotation_db_2.genomic_annotations Iceberg table
+created by schema_2.py.
+
+Denormalized: one row per feature with parent IDs embedded as a list.
+"""
+
+import argparse
+import os
+import sys
+import gzip
+import pyarrow as pa
+from urllib.parse import unquote
+from pyiceberg.exceptions import NoSuchTableError
+from utils import load_s3_tables_catalog, retry_operation
+import boto3
+from io import TextIOWrapper
+
+# Configuration
+NAMESPACE = "annotation_db_2"
+TABLE_NAME = "genomic_annotations"
+BATCH_SIZE = 100000
+
+# Reserved GFF3 attributes extracted into dedicated columns
+RESERVED_ATTRIBUTES = {'ID', 'Name', 'Parent', 'Dbxref', 'Ontology_term', 'Is_circular'}
+
+
+def parse_s3_uri(s3_uri):
+    """Parse S3 URI and return bucket and key."""
+    if not s3_uri.startswith('s3://'):
+        raise ValueError(f"Invalid S3 URI format: {s3_uri}")
+    s3_parts = s3_uri[5:].split('/', 1)
+    if len(s3_parts) != 2 or not s3_parts[0] or not s3_parts[1]:
+        raise ValueError(f"Invalid S3 URI — missing bucket or key: {s3_uri}")
+    return s3_parts[0], s3_parts[1]
+
+
+def get_table():
+    """Get the existing table or fail if it doesn't exist."""
+    catalog = load_s3_tables_catalog(bucket_arn)
+
+    try:
+        namespaces = [ns[0] for ns in catalog.list_namespaces()]
+        if NAMESPACE not in namespaces:
+            print(f"Error: Namespace '{NAMESPACE}' does not exist.")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error checking namespaces: {e}")
+        sys.exit(1)
+
+    table_identifier = f"{NAMESPACE}.{TABLE_NAME}"
+    try:
+        return catalog.load_table(table_identifier)
+    except NoSuchTableError:
+        print(f"Error: Table '{table_identifier}' does not exist.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error loading table: {e}")
+        sys.exit(1)
+
+
+def open_gff3_file(file_path):
+    """Open a GFF3 file, handling local files, S3 URIs, and gzip."""
+    if file_path.startswith('s3://'):
+        bucket, key = parse_s3_uri(file_path)
+        s3_client = boto3.client('s3')
+        response = s3_client.get_object(Bucket=bucket, Key=key)
+        if file_path.endswith('.gz'):
+            return TextIOWrapper(gzip.GzipFile(fileobj=response['Body']))
+        else:
+            return TextIOWrapper(response['Body'])
+    else:
+        if file_path.endswith('.gz'):
+            return gzip.open(file_path, 'rt')
+        else:
+            return open(file_path, 'r')
+
+
+def parse_gff3_attributes(attr_str):
+    """Parse GFF3 column 9 attributes with URL-decoding."""
+    if attr_str == '.' or not attr_str.strip():
+        return {}
+
+    attrs = {}
+    for item in attr_str.split(';'):
+        item = item.strip()
+        if not item:
+            continue
+        if '=' in item:
+            key, value = item.split('=', 1)
+            attrs[unquote(key)] = unquote(value)
+        else:
+            attrs[unquote(item)] = 'true'
+    return attrs
+
+
+def parse_gff3_header(gff3_file):
+    """Parse GFF3 header directives. Returns (directives, first_data_line)."""
+    directives = []
+    first_data_line = None
+
+    for line in gff3_file:
+        line = line.rstrip('\n\r')
+        if not line or line.startswith('###'):
+            continue
+        if line.startswith('##'):
+            parts = line[2:].strip().split(None, 1)
+            key = parts[0] if parts else ''
+            value = parts[1] if len(parts) > 1 else ''
+            directives.append((key, value))
+            continue
+        if line.startswith('#'):
+            continue
+        first_data_line = line
+        break
+
+    return directives, first_data_line
+
+
+def process_gff3_batch(batch_lines):
+    """Process a batch of GFF3 data lines into PyArrow arrays."""
+    feature_id_list = []
+    seqid_list = []
+    source_list = []
+    type_list = []
+    start_list = []
+    end_list = []
+    score_list = []
+    strand_list = []
+    phase_list = []
+    name_list = []
+    parent_ids_list = []
+    dbxref_list = []
+    ontology_term_list = []
+    is_circular_list = []
+    attributes_list = []
+
+    for line in batch_lines:
+        fields = line.split('\t')
+        if len(fields) < 9:
+            print(f"Warning: Skipping malformed GFF3 line (< 9 fields): {line[:80]}")
+            continue
+
+        seqid = unquote(fields[0])
+        source = unquote(fields[1])
+        feat_type = unquote(fields[2])
+
+        try:
+            start = int(fields[3])
+            end = int(fields[4])
+        except ValueError:
+            print(f"Warning: Invalid start/end in GFF3 line: {line[:80]}")
+            continue
+
+        score = None
+        if fields[5] != '.':
+            try:
+                score = float(fields[5])
+            except ValueError:
+                pass
+
+        strand = fields[6] if fields[6] != '.' else None
+        phase = fields[7] if fields[7] != '.' else None
+
+        attrs = parse_gff3_attributes(fields[8])
+
+        feature_id = attrs.get('ID', f"{seqid}:{feat_type}:{start}-{end}")
+        name = attrs.get('Name')
+        dbxref = attrs.get('Dbxref')
+        ontology_term = attrs.get('Ontology_term')
+        is_circular = attrs.get('Is_circular', '').lower() == 'true' if 'Is_circular' in attrs else None
+
+        # Parent IDs as a list
+        parent_str = attrs.get('Parent')
+        parent_ids = [p.strip() for p in parent_str.split(',')] if parent_str else []
+
+        # Remaining attributes
+        remaining_attrs = {k: v for k, v in attrs.items() if k not in RESERVED_ATTRIBUTES}
+
+        feature_id_list.append(feature_id)
+        seqid_list.append(seqid)
+        source_list.append(source)
+        type_list.append(feat_type)
+        start_list.append(start)
+        end_list.append(end)
+        score_list.append(score)
+        strand_list.append(strand)
+        phase_list.append(phase)
+        name_list.append(name)
+        parent_ids_list.append(parent_ids)
+        dbxref_list.append(dbxref)
+        ontology_term_list.append(ontology_term)
+        is_circular_list.append(is_circular)
+        attributes_list.append(remaining_attrs)
+
+    return {
+        'feature_id': pa.array(feature_id_list, type=pa.string()),
+        'seqid': pa.array(seqid_list, type=pa.string()),
+        'source': pa.array(source_list, type=pa.string()),
+        'type': pa.array(type_list, type=pa.string()),
+        'start': pa.array(start_list, type=pa.int64()),
+        'end': pa.array(end_list, type=pa.int64()),
+        'score': pa.array(score_list, type=pa.float64()),
+        'strand': pa.array(strand_list, type=pa.string()),
+        'phase': pa.array(phase_list, type=pa.string()),
+        'name': pa.array(name_list, type=pa.string()),
+        'parent_ids': pa.array(parent_ids_list, type=pa.list_(pa.string())),
+        'dbxref': pa.array(dbxref_list, type=pa.string()),
+        'ontology_term': pa.array(ontology_term_list, type=pa.string()),
+        'is_circular': pa.array(is_circular_list, type=pa.bool_()),
+        'attributes': pa.array(
+            [{str(k): str(v) for k, v in d.items()} for d in attributes_list],
+            type=pa.map_(pa.string(), pa.string())),
+    }
+
+
+def write_to_iceberg(table, data_arrays, pyarrow_schema):
+    """Write data to the Iceberg table."""
+    columns = [data_arrays[field.name] for field in pyarrow_schema]
+    arrow_table = pa.Table.from_arrays(columns, schema=pyarrow_schema)
+
+    print(f"Writing {len(arrow_table)} rows to {NAMESPACE}.{TABLE_NAME}...")
+
+    def is_commit_failed(e):
+        return "CommitFailedException" in str(e) and "branch main has changed" in str(e)
+
+    retry_operation(
+        table.append,
+        arrow_table,
+        max_retries=5,
+        retry_condition=is_commit_failed,
+    )
+    print(f"Successfully wrote {len(arrow_table)} rows to {NAMESPACE}.{TABLE_NAME}")
+
+
+def process_gff3_file(gff3_path, table=None, pyarrow_schema=None):
+    """Process a GFF3 file in batches and write to Iceberg table."""
+    print(f"Processing GFF3 file: {gff3_path}")
+
+    with open_gff3_file(gff3_path) as gff3_file:
+        directives, first_line = parse_gff3_header(gff3_file)
+
+        for key, value in directives:
+            print(f"  Directive: ##{key} {value}")
+
+        batch_lines = []
+        if first_line:
+            batch_lines.append(first_line)
+
+        records_processed = 0
+
+        for line in gff3_file:
+            line = line.rstrip('\n\r')
+            if not line or line.startswith('#'):
+                continue
+            if line.startswith('>'):
+                break
+
+            batch_lines.append(line)
+
+            if len(batch_lines) >= BATCH_SIZE:
+                data_arrays = process_gff3_batch(batch_lines)
+                if table and pyarrow_schema:
+                    write_to_iceberg(table, data_arrays, pyarrow_schema)
+                    records_processed += len(batch_lines)
+                    print(f"Processed {records_processed} records so far...")
+                else:
+                    return data_arrays
+                batch_lines = []
+
+        if batch_lines:
+            data_arrays = process_gff3_batch(batch_lines)
+            if table and pyarrow_schema:
+                write_to_iceberg(table, data_arrays, pyarrow_schema)
+                records_processed += len(batch_lines)
+                print(f"Processed {records_processed} records total.")
+                return None
+            else:
+                return data_arrays
+
+    return None
+
+
+def main():
+    global bucket_arn, NAMESPACE, TABLE_NAME, BATCH_SIZE
+
+    parser = argparse.ArgumentParser(description='Load GFF3 files into Iceberg table (Schema 2)')
+    parser.add_argument('gff3_files', nargs='+', help='GFF3 file paths to load (local or s3://)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    parser.add_argument('--namespace', default=NAMESPACE, help=f'Iceberg namespace (default: {NAMESPACE})')
+    parser.add_argument('--table', default=TABLE_NAME, help=f'Table name (default: {TABLE_NAME})')
+    parser.add_argument('--batch-size', type=int, default=BATCH_SIZE,
+                        help=f'Records per batch (default: {BATCH_SIZE})')
+    args = parser.parse_args()
+
+    bucket_arn = args.bucket_arn
+    NAMESPACE = args.namespace
+    TABLE_NAME = args.table
+    BATCH_SIZE = args.batch_size
+
+    print("Getting table...")
+    table = get_table()
+    pyarrow_schema = table.schema().as_arrow()
+
+    for gff3_file in args.gff3_files:
+        file_exists = True
+        if gff3_file.startswith('s3://'):
+            try:
+                bucket, key = parse_s3_uri(gff3_file)
+                s3_client = boto3.client('s3')
+                s3_client.head_object(Bucket=bucket, Key=key)
+            except Exception as e:
+                file_exists = False
+                print(f"Error: S3 file not found: {gff3_file} — {e}")
+        else:
+            file_exists = os.path.exists(gff3_file)
+            if not file_exists:
+                print(f"Error: Local file not found: {gff3_file}")
+
+        if not file_exists:
+            continue
+
+        try:
+            process_gff3_file(gff3_file, table, pyarrow_schema)
+        except Exception as e:
+            print(f"Error processing file {gff3_file}: {e}")
+            import traceback
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation-database/metadata_schema.py
+++ b/annotation-database/metadata_schema.py
@@ -1,0 +1,156 @@
+"""
+Metadata schema for GFF3 file-level directives and pragmas.
+
+Captures GFF3 header information:
+  - gff_files: Tracks loaded GFF3 files
+  - sequence_regions: ##sequence-region directives
+  - header_metadata: All other ## directives (species, genome-build, etc.)
+"""
+
+from typing import Dict
+from pyiceberg.catalog import Catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.types import (
+    NestedField,
+    StringType,
+    LongType,
+    UUIDType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import BucketTransform
+from pyiceberg.table.sorting import (
+    SortOrder, SortField, SortDirection, NullOrder
+)
+from pyiceberg.transforms import IdentityTransform
+from utils import create_table, load_s3_tables_catalog
+
+
+# ─── gff_files table ──────────────────────────────────────────────────────────
+
+gff_files_schema: Schema = Schema(
+    NestedField(1, "file_id", UUIDType(), required=True),
+    NestedField(2, "file_name", StringType(), required=True),
+    NestedField(3, "gff_version", StringType(),
+                doc="GFF version from ##gff-version directive"),
+    NestedField(4, "created_at", LongType(), required=True,
+                doc="Epoch millis when the file was loaded"),
+)
+
+gff_files_sort_order: SortOrder = SortOrder(
+    SortField(source_id=2,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+# ─── sequence_regions table ───────────────────────────────────────────────────
+# From ##sequence-region seqid start end
+
+sequence_regions_schema: Schema = Schema(
+    NestedField(1, "region_id", UUIDType(), required=True),
+    NestedField(2, "file_id", UUIDType(), required=True),
+    NestedField(3, "seqid", StringType(), required=True),
+    NestedField(4, "start", LongType(), required=True),
+    NestedField(5, "end", LongType(), required=True),
+)
+
+sequence_regions_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=100,
+                   transform=BucketTransform(16),
+                   name="file_id_bucket"),
+)
+
+
+# ─── header_metadata table ────────────────────────────────────────────────────
+# All other ## directives: ##species, ##genome-build, etc.
+
+header_metadata_schema: Schema = Schema(
+    NestedField(1, "metadata_id", UUIDType(), required=True),
+    NestedField(2, "file_id", UUIDType(), required=True),
+    NestedField(3, "directive", StringType(), required=True,
+                doc="Directive name (e.g., species, genome-build)"),
+    NestedField(4, "value", StringType(), required=True,
+                doc="Directive value"),
+)
+
+header_metadata_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=100,
+                   transform=BucketTransform(16),
+                   name="file_id_bucket"),
+)
+
+
+def create_schema_tables(catalog: Catalog, namespace: str) -> Dict[str, Table]:
+    table_name_gff_files = "gff_files"
+    table_name_sequence_regions = "sequence_regions"
+    table_name_header_metadata = "header_metadata"
+
+    print(f"Creating metadata tables in namespace {namespace} ...")
+
+    print(f"Creating {table_name_gff_files}")
+    gff_files: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_gff_files,
+        schema=gff_files_schema,
+        partition_spec=None,
+        sort_order=gff_files_sort_order)
+    print(f"Created {gff_files}")
+
+    print(f"Creating {table_name_sequence_regions}")
+    sequence_regions: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_sequence_regions,
+        schema=sequence_regions_schema,
+        partition_spec=sequence_regions_partition_spec,
+        sort_order=None)
+    print(f"Created {sequence_regions}")
+
+    print(f"Creating {table_name_header_metadata}")
+    header_metadata: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_header_metadata,
+        schema=header_metadata_schema,
+        partition_spec=header_metadata_partition_spec,
+        sort_order=None)
+    print(f"Created {header_metadata}")
+
+    return {
+        table_name_gff_files: gff_files,
+        table_name_sequence_regions: sequence_regions,
+        table_name_header_metadata: header_metadata,
+    }
+
+
+def main():
+    from utils import create_namespace
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Create metadata tables for GFF3 annotation data')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    parser.add_argument('--namespace', required=True, help='Namespace for tables')
+    args = parser.parse_args()
+
+    print("Connecting to catalog ...")
+    catalog = load_s3_tables_catalog(args.bucket_arn)
+    print("Connected to catalog")
+
+    print("Creating namespace ...")
+    create_namespace(catalog, args.namespace)
+    print("Namespace created")
+
+    print("Creating tables ...")
+    create_schema_tables(catalog, args.namespace)
+    print("Tables created")
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation-database/requirements.txt
+++ b/annotation-database/requirements.txt
@@ -1,0 +1,4 @@
+pyiceberg>=0.9.0
+pyiceberg-core>=0.4.0
+boto3>=1.37.26
+pyarrow>=19.0.1

--- a/annotation-database/schema_1.py
+++ b/annotation-database/schema_1.py
@@ -1,0 +1,215 @@
+"""
+Schema 1: Normalized schema for GFF3 annotation data.
+
+Three tables in namespace `annotation_db`:
+
+1. features       - Core annotation features (gene, mRNA, exon, CDS, etc.)
+2. sources        - Annotation sources/programs that produced features
+3. feature_relationships - Parent-child relationships between features
+
+Partitioning:
+  - features: by seqid (chromosome) and type_bucket (128 buckets on feature type)
+  - sources: unpartitioned (small cardinality)
+  - feature_relationships: by seqid (chromosome)
+
+This design favors data integrity and minimal redundancy. Joins are required
+to traverse the feature hierarchy (gene -> mRNA -> exon/CDS).
+"""
+
+from typing import Dict
+from pyiceberg.catalog import Catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.types import (
+    NestedField,
+    StringType,
+    LongType,
+    DoubleType,
+    MapType,
+    BooleanType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import IdentityTransform, BucketTransform
+from pyiceberg.table.sorting import (
+    SortOrder, SortField, SortDirection, NullOrder
+)
+from utils import create_table, load_s3_tables_catalog
+import time
+
+
+# ─── features table ───────────────────────────────────────────────────────────
+# One row per GFF3 feature line.
+# Reserved GFF3 attributes (ID, Name, Dbxref, Ontology_term, Is_circular)
+# are extracted into dedicated columns. Remaining attributes go into the map.
+
+features_schema: Schema = Schema(
+    NestedField(1, "feature_id", StringType(), required=True,
+                doc="GFF3 ID attribute — unique identifier for this feature"),
+    NestedField(2, "seqid", StringType(), required=True,
+                doc="Landmark / chromosome identifier (GFF3 column 1)"),
+    NestedField(3, "source", StringType(), required=True,
+                doc="Source of the annotation (GFF3 column 2)"),
+    NestedField(4, "type", StringType(), required=True,
+                doc="Feature type / SO term (GFF3 column 3)"),
+    NestedField(5, "start", LongType(), required=True,
+                doc="Start position, 1-based inclusive (GFF3 column 4)"),
+    NestedField(6, "end", LongType(), required=True,
+                doc="End position, 1-based inclusive (GFF3 column 5)"),
+    NestedField(7, "score", DoubleType(),
+                doc="Score value (GFF3 column 6), null if '.'"),
+    NestedField(8, "strand", StringType(),
+                doc="Strand: +, -, ., or ? (GFF3 column 7)"),
+    NestedField(9, "phase", StringType(),
+                doc="CDS phase: 0, 1, 2, or . (GFF3 column 8)"),
+    NestedField(10, "name", StringType(),
+                doc="GFF3 Name attribute — display name"),
+    NestedField(11, "dbxref", StringType(),
+                doc="GFF3 Dbxref attribute — database cross-references (comma-separated)"),
+    NestedField(12, "ontology_term", StringType(),
+                doc="GFF3 Ontology_term attribute (comma-separated)"),
+    NestedField(13, "is_circular", BooleanType(),
+                doc="GFF3 Is_circular attribute"),
+    NestedField(14, "attributes", MapType(key_id=15,
+                                          value_id=16,
+                                          key_type=StringType(),
+                                          value_type=StringType()),
+                doc="All remaining GFF3 column 9 attributes as key-value pairs"),
+)
+
+features_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=1000,
+                   transform=IdentityTransform(),
+                   name="seqid"),
+    PartitionField(source_id=4,
+                   field_id=1001,
+                   transform=BucketTransform(128),
+                   name="type_bucket"),
+)
+
+features_sort_order: SortOrder = SortOrder(
+    SortField(source_id=5,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+# ─── sources table ────────────────────────────────────────────────────────────
+# Distinct annotation sources encountered across loaded GFF3 files.
+
+sources_schema: Schema = Schema(
+    NestedField(1, "source_name", StringType(), required=True,
+                doc="Unique source/program name from GFF3 column 2"),
+    NestedField(2, "description", StringType(),
+                doc="Optional description of the source"),
+)
+
+
+# ─── feature_relationships table ──────────────────────────────────────────────
+# Parent-child edges derived from the GFF3 Parent attribute.
+# A feature with Parent=mRNA00001,mRNA00002 produces two rows.
+
+feature_relationships_schema: Schema = Schema(
+    NestedField(1, "child_id", StringType(), required=True,
+                doc="Feature ID of the child"),
+    NestedField(2, "parent_id", StringType(), required=True,
+                doc="Feature ID of the parent"),
+    NestedField(3, "seqid", StringType(), required=True,
+                doc="Chromosome — denormalized for partition-aligned joins"),
+    NestedField(4, "child_type", StringType(),
+                doc="Feature type of the child (e.g., exon, CDS)"),
+    NestedField(5, "parent_type", StringType(),
+                doc="Feature type of the parent (e.g., gene, mRNA)"),
+)
+
+feature_relationships_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=3,
+                   field_id=1000,
+                   transform=IdentityTransform(),
+                   name="seqid"),
+)
+
+feature_relationships_sort_order: SortOrder = SortOrder(
+    SortField(source_id=2,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+def create_schema_tables(catalog: Catalog, namespace: str) -> Dict[str, Table]:
+    table_name_features = "features"
+    table_name_sources = "sources"
+    table_name_relationships = "feature_relationships"
+
+    print(f"Creating tables in namespace {namespace} ...")
+
+    print(f"Creating {table_name_features}")
+    features: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_features,
+        schema=features_schema,
+        partition_spec=features_partition_spec,
+        sort_order=features_sort_order)
+    print(f"Created {features}")
+
+    time.sleep(3)
+
+    print(f"Creating {table_name_sources}")
+    sources: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_sources,
+        schema=sources_schema,
+        partition_spec=None,
+        sort_order=None)
+    print(f"Created {sources}")
+
+    time.sleep(3)
+
+    print(f"Creating {table_name_relationships}")
+    relationships: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_relationships,
+        schema=feature_relationships_schema,
+        partition_spec=feature_relationships_partition_spec,
+        sort_order=feature_relationships_sort_order)
+    print(f"Created {relationships}")
+
+    time.sleep(3)
+
+    return {
+        table_name_features: features,
+        table_name_sources: sources,
+        table_name_relationships: relationships,
+    }
+
+
+def main():
+    import argparse
+    from utils import create_namespace
+
+    parser = argparse.ArgumentParser(
+        description='Create Iceberg tables for GFF3 annotation data (Schema 1 — normalized)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    args = parser.parse_args()
+
+    print("Connecting to catalog ...")
+    catalog = load_s3_tables_catalog(args.bucket_arn)
+    print("Connected to catalog")
+
+    namespace = "annotation_db"
+    print("Creating namespace ...")
+    create_namespace(catalog, namespace)
+    print("Namespace created")
+
+    print("Creating tables ...")
+    create_schema_tables(catalog, namespace)
+    print("Tables created")
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation-database/schema_2.py
+++ b/annotation-database/schema_2.py
@@ -1,0 +1,144 @@
+"""
+Schema 2: Denormalized schema for GFF3 annotation data.
+
+Single table in namespace `annotation_db_2`:
+
+1. genomic_annotations - All feature data with parent info embedded
+
+Partitioning:
+  - by seqid (chromosome) and type_bucket (128 buckets on feature type)
+  - sorted by start position
+
+This design favors fast single-region queries without joins. Parent IDs are
+stored as a list directly on each feature row. Trade-off is that source
+metadata is duplicated across rows.
+"""
+
+from typing import Dict
+from pyiceberg.catalog import Catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.types import (
+    NestedField,
+    StringType,
+    LongType,
+    DoubleType,
+    MapType,
+    BooleanType,
+    ListType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import IdentityTransform, BucketTransform
+from pyiceberg.table.sorting import (
+    SortOrder, SortField, SortDirection, NullOrder
+)
+from utils import create_table, load_s3_tables_catalog
+
+
+genomic_annotations_schema: Schema = Schema(
+    NestedField(1, "feature_id", StringType(), required=True,
+                doc="GFF3 ID attribute — unique identifier for this feature"),
+    NestedField(2, "seqid", StringType(), required=True,
+                doc="Landmark / chromosome identifier (GFF3 column 1)"),
+    NestedField(3, "source", StringType(), required=True,
+                doc="Source of the annotation (GFF3 column 2)"),
+    NestedField(4, "type", StringType(), required=True,
+                doc="Feature type / SO term (GFF3 column 3)"),
+    NestedField(5, "start", LongType(), required=True,
+                doc="Start position, 1-based inclusive (GFF3 column 4)"),
+    NestedField(6, "end", LongType(), required=True,
+                doc="End position, 1-based inclusive (GFF3 column 5)"),
+    NestedField(7, "score", DoubleType(),
+                doc="Score value (GFF3 column 6), null if '.'"),
+    NestedField(8, "strand", StringType(),
+                doc="Strand: +, -, ., or ? (GFF3 column 7)"),
+    NestedField(9, "phase", StringType(),
+                doc="CDS phase: 0, 1, 2, or . (GFF3 column 8)"),
+    NestedField(10, "name", StringType(),
+                doc="GFF3 Name attribute — display name"),
+    NestedField(11, "parent_ids", ListType(element_id=1000,
+                                           element_type=StringType(),
+                                           element_required=True),
+                doc="GFF3 Parent attribute — list of parent feature IDs"),
+    NestedField(12, "dbxref", StringType(),
+                doc="GFF3 Dbxref attribute — database cross-references (comma-separated)"),
+    NestedField(13, "ontology_term", StringType(),
+                doc="GFF3 Ontology_term attribute (comma-separated)"),
+    NestedField(14, "is_circular", BooleanType(),
+                doc="GFF3 Is_circular attribute"),
+    NestedField(15, "attributes", MapType(key_id=16,
+                                          value_id=17,
+                                          key_type=StringType(),
+                                          value_type=StringType()),
+                doc="All remaining GFF3 column 9 attributes as key-value pairs"),
+    identifier_field_ids=[1, 2, 4, 5]
+)
+
+genomic_annotations_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=1001,
+                   transform=IdentityTransform(),
+                   name="seqid"),
+    PartitionField(source_id=4,
+                   field_id=1002,
+                   transform=BucketTransform(128),
+                   name="type_bucket"),
+)
+
+genomic_annotations_sort_order: SortOrder = SortOrder(
+    SortField(source_id=2,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+    SortField(source_id=5,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+def create_schema_tables(catalog: Catalog, namespace: str) -> Dict[str, Table]:
+    table_name = "genomic_annotations"
+
+    print(f"Creating tables in namespace {namespace} ...")
+    print(f"Creating {table_name}")
+    genomic_annotations: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name,
+        schema=genomic_annotations_schema,
+        partition_spec=genomic_annotations_partition_spec,
+        sort_order=genomic_annotations_sort_order)
+    print(f"Created {genomic_annotations}")
+
+    return {
+        table_name: genomic_annotations,
+    }
+
+
+def main():
+    import argparse
+    from utils import create_namespace
+
+    parser = argparse.ArgumentParser(
+        description='Create Iceberg table for GFF3 annotation data (Schema 2 — denormalized)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    args = parser.parse_args()
+
+    print("Connecting to catalog ...")
+    catalog = load_s3_tables_catalog(args.bucket_arn)
+    print("Connected to catalog")
+
+    namespace = "annotation_db_2"
+    print("Creating namespace ...")
+    create_namespace(catalog, namespace)
+    print("Namespace created")
+
+    print("Creating tables ...")
+    create_schema_tables(catalog, namespace)
+    print("Tables created")
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/annotation-database/setup.sh
+++ b/annotation-database/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Activate the virtual environment
+echo "Activating virtual environment..."
+source venv/bin/activate
+
+# Install required packages
+echo "Installing required packages..."
+pip install -r requirements.txt
+
+# Display installed packages
+echo "Installed packages:"
+pip list
+
+echo ""
+echo "Virtual environment setup complete!"
+echo "To activate the virtual environment, run: source venv/bin/activate"
+echo "To deactivate the virtual environment, run: deactivate"

--- a/annotation-database/utils.py
+++ b/annotation-database/utils.py
@@ -1,0 +1,103 @@
+import boto3
+from pyiceberg.catalog import Catalog, load_catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.table.sorting import SortOrder
+from pyiceberg.partitioning import PartitionSpec
+
+
+def create_table(catalog: Catalog,
+                 namespace: str,
+                 table_name: str,
+                 schema: Schema,
+                 partition_spec: PartitionSpec = None,
+                 sort_order: SortOrder = None) -> Table:
+    """Create an Iceberg Table given the relevant information."""
+
+    if catalog.table_exists(f"{namespace}.{table_name}"):
+        print(f"Table {namespace}.{table_name} already exists.")
+        return catalog.load_table(f"{namespace}.{table_name}")
+
+    create_table_args = {
+        "identifier": f"{namespace}.{table_name}",
+        "schema": schema,
+        "properties": {"format-version": "2"}
+    }
+
+    if partition_spec is not None:
+        create_table_args["partition_spec"] = partition_spec
+
+    if sort_order is not None:
+        create_table_args["sort_order"] = sort_order
+
+    table = catalog.create_table(**create_table_args)
+    print(f"Created table: {namespace}.{table_name}")
+    print(f"Table location: {table.location()}")
+    return table
+
+
+def create_namespace(catalog: Catalog, namespace: str) -> None:
+    """Create a namespace in the Catalog."""
+    try:
+        catalog.create_namespace(namespace)
+        print(f"Created namespace: {namespace}")
+    except Exception as e:
+        if "already exists" in str(e):
+            print(f"Namespace {namespace} already exists.")
+        else:
+            raise e
+
+
+def get_aws_account_id() -> str:
+    """Get AWS account ID using boto3."""
+    sts = boto3.client('sts')
+    return sts.get_caller_identity()['Account']
+
+
+def get_aws_region() -> str:
+    """Get AWS region using boto3."""
+    session = boto3.session.Session()
+    return session.region_name or 'us-east-1'
+
+
+def load_s3_tables_catalog(bucket_arn: str) -> Catalog:
+    """Connect to an S3 Tables Iceberg catalog."""
+    region = get_aws_region()
+    catalog_config = {
+        "type": "rest",
+        "warehouse": bucket_arn,
+        "uri": f"https://s3tables.{region}.amazonaws.com/iceberg",
+        "rest.sigv4-enabled": "true",
+        "rest.signing-name": "s3tables",
+        "rest.signing-region": region
+    }
+    catalog = load_catalog("s3tables", **catalog_config)
+    return catalog
+
+
+def retry_operation(operation, *args, max_retries=5, retry_condition=None, **kwargs):
+    """Retry an operation with exponential backoff."""
+    import time
+
+    retry_count = 0
+    last_exception = None
+
+    while retry_count < max_retries:
+        try:
+            result = operation(*args, **kwargs)
+            return result
+        except Exception as e:
+            retry_count += 1
+            last_exception = e
+
+            should_retry = retry_condition(e) if retry_condition else True
+
+            if should_retry and retry_count < max_retries:
+                print(f"Operation failed. Retry attempt {retry_count}/{max_retries}...")
+                time.sleep(retry_count * 2)
+            else:
+                raise e
+
+    if last_exception:
+        print(f"Failed after {max_retries} attempts.")
+        raise last_exception

--- a/templates/gff3-to-iceberg/.dockerignore
+++ b/templates/gff3-to-iceberg/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore unnecessary files during Docker build
+*.md
+.git
+.gitignore
+*.sh
+results/
+work/

--- a/templates/gff3-to-iceberg/Dockerfile
+++ b/templates/gff3-to-iceberg/Dockerfile
@@ -1,0 +1,30 @@
+FROM public.ecr.aws/docker/library/python:3.10-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --only-binary=pyiceberg-core -r requirements.txt
+
+COPY schema_1.py .
+COPY schema_2.py .
+COPY load_gff3_schema1.py .
+COPY load_gff3_schema2.py .
+COPY utils.py .
+COPY metadata_schema.py .
+
+COPY validate_inputs.py .
+COPY setup_catalog.py .
+COPY check_connectivity.py .
+COPY check_permissions.py .
+COPY initialize_tables.py .
+COPY load_gff3_wrapper.py .
+COPY generate_summary.py .
+
+ENV PYTHONPATH=/app:${PYTHONPATH}
+
+CMD ["/bin/bash"]

--- a/templates/gff3-to-iceberg/README.md
+++ b/templates/gff3-to-iceberg/README.md
@@ -1,0 +1,63 @@
+# HealthOmics GFF3 Annotation Loader Workflow
+
+A WDL workflow that loads GFF3 (Generic Feature Format version 3) files into Apache Iceberg tables on AWS. Runs in AWS HealthOmics and supports both S3 Tables (managed Iceberg catalog) and vanilla Iceberg with Glue catalog and S3 storage.
+
+> **VPC Connectivity Required:** Both catalog types require VPC-connected workflow runs.
+
+## Quick Start
+
+1. Build and push the container to ECR (see below)
+2. Deploy the workflow to HealthOmics using `main.wdl`
+3. Start a VPC-connected run with your parameters
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `gff3_file` | File | Yes | — | S3 URI to GFF3 file (`.gff3` or `.gff3.gz`) |
+| `schema` | String | Yes | — | Schema design: `1` (normalized) or `2` (denormalized) |
+| `destination` | String | Yes | — | S3 Tables ARN or `bucket/path` (no `s3://` prefix) |
+| `container` | String | Yes | — | Container image URI |
+| `namespace` | String | No | Auto | Iceberg namespace |
+| `batch_size` | Int | No | `100000` | Records per processing batch |
+
+## Schema Selection
+
+| Schema | Tables | Best For |
+|--------|--------|----------|
+| **1** | `features`, `sources`, `feature_relationships` | Data integrity, hierarchy traversal |
+| **2** | `genomic_annotations` | Fast region queries, simplicity |
+
+### Default Namespaces
+
+- Schema 1: `annotation_db`
+- Schema 2: `annotation_db_2`
+
+## Workflow Stages
+
+1. **Validate Inputs** — Checks GFF3 file, schema, destination
+2. **Setup Catalog** — Configures S3 Tables REST or Glue catalog
+3. **Check Connectivity** — Validates VPC network access
+4. **Check Permissions** — Probes AWS permissions
+5. **Initialize Tables** — Creates tables if they don't exist
+6. **Load GFF3** — Parses features in batches, writes to Iceberg
+7. **Generate Summary** — Produces JSON summary
+
+## Building the Container
+
+```bash
+# Build locally
+./build_container.sh
+
+# Build and push to ECR
+./build_and_push_container.sh \
+  --account-id 123456789012 \
+  --region us-east-1 \
+  --repo healthomics-gff3-loader \
+  --tag v1.0.0 \
+  --docker
+```
+
+## AWS Permissions
+
+Same as the VCF loader — see the variant-database workflow README for IAM policy examples for S3 Tables and Glue catalog destinations.

--- a/templates/gff3-to-iceberg/build_and_push_container.sh
+++ b/templates/gff3-to-iceberg/build_and_push_container.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_NAME="healthomics-gff3-loader"
+IMAGE_TAG="latest"
+SKIP_BUILD=false
+CONTAINER_RUNTIME="finch"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --account-id) AWS_ACCOUNT_ID="$2"; shift 2 ;;
+        --region) AWS_REGION="$2"; shift 2 ;;
+        --repo) REPO_NAME="$2"; shift 2 ;;
+        --tag) IMAGE_TAG="$2"; shift 2 ;;
+        --skip-build) SKIP_BUILD=true; shift ;;
+        --docker) CONTAINER_RUNTIME="docker"; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [ -z "${AWS_ACCOUNT_ID:-}" ]; then echo "Error: --account-id is required"; exit 1; fi
+if [ -z "${AWS_REGION:-}" ]; then echo "Error: --region is required"; exit 1; fi
+
+ECR_URI="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+FULL_IMAGE="${ECR_URI}/${REPO_NAME}:${IMAGE_TAG}"
+LOCAL_IMAGE="${REPO_NAME}:${IMAGE_TAG}"
+
+echo "============================================"
+echo "HealthOmics GFF3 Loader - Build & Push to ECR"
+echo "============================================"
+echo "Account:   ${AWS_ACCOUNT_ID}"
+echo "Region:    ${AWS_REGION}"
+echo "Repo:      ${REPO_NAME}"
+echo "Tag:       ${IMAGE_TAG}"
+echo "ECR Image: ${FULL_IMAGE}"
+echo "============================================"
+
+if [ "${SKIP_BUILD}" = false ]; then
+    echo ">> Building container for amd64..."
+    ${CONTAINER_RUNTIME} build --platform linux/amd64 -t "${LOCAL_IMAGE}" .
+    echo "   Build complete."
+fi
+
+echo ">> Authenticating to ECR..."
+aws ecr get-login-password --region "${AWS_REGION}" | \
+    ${CONTAINER_RUNTIME} login --username AWS --password-stdin "${ECR_URI}"
+
+echo ">> Ensuring ECR repository exists..."
+aws ecr describe-repositories --repository-names "${REPO_NAME}" --region "${AWS_REGION}" > /dev/null 2>&1 || \
+aws ecr create-repository --repository-name "${REPO_NAME}" --region "${AWS_REGION}" --image-scanning-configuration scanOnPush=true
+
+echo ">> Setting ECR repository policy for HealthOmics..."
+POLICY_JSON=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AllowHealthOmicsAccess",
+    "Effect": "Allow",
+    "Principal": {"Service": "omics.amazonaws.com"},
+    "Action": ["ecr:GetDownloadUrlForLayer","ecr:BatchGetImage","ecr:BatchCheckLayerAvailability"],
+    "Condition": {"StringEquals": {"aws:SourceAccount": "${AWS_ACCOUNT_ID}"}}
+  }]
+}
+EOF
+)
+aws ecr set-repository-policy --repository-name "${REPO_NAME}" --region "${AWS_REGION}" --policy-text "${POLICY_JSON}" > /dev/null
+
+echo ">> Tagging and pushing..."
+${CONTAINER_RUNTIME} tag "${LOCAL_IMAGE}" "${FULL_IMAGE}"
+${CONTAINER_RUNTIME} push "${FULL_IMAGE}"
+
+echo "============================================"
+echo "Push complete!"
+echo "Image URI: ${FULL_IMAGE}"
+echo "============================================"

--- a/templates/gff3-to-iceberg/build_container.sh
+++ b/templates/gff3-to-iceberg/build_container.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+CONTAINER_RUNTIME="docker"
+IMAGE_TAG="latest"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tag) IMAGE_TAG="$2"; shift 2 ;;
+        --finch) CONTAINER_RUNTIME="finch"; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+echo "Building healthomics-gff3-loader:${IMAGE_TAG} for linux/amd64..."
+${CONTAINER_RUNTIME} build --platform linux/amd64 -t "healthomics-gff3-loader:${IMAGE_TAG}" .
+echo "Build complete."

--- a/templates/gff3-to-iceberg/check_connectivity.py
+++ b/templates/gff3-to-iceberg/check_connectivity.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+Network connectivity checker for HealthOmics VCF Loader workflow.
+
+Validates that the workflow run has network access to the AWS service
+endpoints required by the selected catalog type. This catches VPC
+networking misconfigurations early with clear, actionable error messages.
+
+Required connectivity by catalog type:
+
+  Vanilla (Glue catalog):
+    - AWS STS (credential validation)
+    - AWS Glue API
+    - AWS Lake Formation API (if governance is enabled)
+    - Amazon S3 (data read/write)
+
+  S3 Tables (REST catalog):
+    - AWS STS (credential validation)
+    - S3 Tables REST API (https://s3tables.{region}.amazonaws.com)
+    - Amazon S3 (data read/write)
+
+Both catalog types require VPC-connected workflow runs in HealthOmics.
+The default RESTRICTED networking mode only provides same-region S3 and
+ECR access, which is NOT sufficient for Glue, Lake Formation, S3 Tables,
+or STS API calls.
+
+Outputs a JSON report with pass/fail per endpoint and remediation guidance.
+"""
+
+import sys
+import json
+import argparse
+import socket
+import ssl
+import urllib.request
+import urllib.error
+import boto3
+from botocore.exceptions import ClientError, EndpointConnectionError, ConnectTimeoutError
+
+
+# Timeout for connectivity probes (seconds)
+CONNECT_TIMEOUT = 10
+
+
+def check_sts_connectivity() -> dict:
+    """
+    Check connectivity to AWS STS by calling GetCallerIdentity.
+
+    STS is required for all catalog types to validate credentials and
+    determine the caller's identity and account.
+    """
+    try:
+        sts = boto3.client("sts")
+        identity = sts.get_caller_identity()
+        return {
+            "endpoint": "sts",
+            "passed": True,
+            "message": f"STS reachable. Caller: {identity['Arn']}",
+        }
+    except (EndpointConnectionError, ConnectTimeoutError) as e:
+        return {
+            "endpoint": "sts",
+            "passed": False,
+            "message": (
+                f"Cannot reach AWS STS: {e}. "
+                "This workflow requires VPC-connected runs in HealthOmics. "
+                "Ensure the run uses networking_mode=VPC with a configuration "
+                "that has private subnets routed through a NAT Gateway, or add "
+                "a com.amazonaws.{region}.sts VPC interface endpoint."
+            ),
+        }
+    except Exception as e:
+        return {
+            "endpoint": "sts",
+            "passed": False,
+            "message": f"STS connectivity check failed: {e}",
+        }
+
+
+def check_glue_connectivity(region: str) -> dict:
+    """
+    Check connectivity to AWS Glue API.
+
+    Glue is the catalog backend for vanilla Iceberg. The workflow needs
+    Glue to create databases, create/update tables, and read table metadata.
+    """
+    try:
+        glue = boto3.client("glue", region_name=region)
+        # Lightweight probe — list databases with limit 1
+        glue.get_databases(MaxResults=1)
+        return {
+            "endpoint": "glue",
+            "passed": True,
+            "message": f"Glue API reachable in {region}.",
+        }
+    except ClientError:
+        # Access denied still means the endpoint is reachable
+        return {
+            "endpoint": "glue",
+            "passed": True,
+            "message": f"Glue API reachable in {region} (permissions checked separately).",
+        }
+    except (EndpointConnectionError, ConnectTimeoutError) as e:
+        return {
+            "endpoint": "glue",
+            "passed": False,
+            "message": (
+                f"Cannot reach AWS Glue in {region}: {e}. "
+                "Ensure the run uses networking_mode=VPC with NAT Gateway access, "
+                "or add a com.amazonaws.{region}.glue VPC interface endpoint."
+            ),
+        }
+    except Exception as e:
+        return {
+            "endpoint": "glue",
+            "passed": False,
+            "message": f"Glue connectivity check failed: {e}",
+        }
+
+
+def check_lakeformation_connectivity(region: str) -> dict:
+    """
+    Check connectivity to AWS Lake Formation API.
+
+    Lake Formation is required when Glue Data Catalog governance is enabled.
+    Even when not governing, the workflow probes LF settings to determine
+    whether explicit grants are needed.
+    """
+    try:
+        lf = boto3.client("lakeformation", region_name=region)
+        lf.get_data_lake_settings()
+        return {
+            "endpoint": "lakeformation",
+            "passed": True,
+            "message": f"Lake Formation API reachable in {region}.",
+        }
+    except ClientError:
+        # Access denied still means the endpoint is reachable
+        return {
+            "endpoint": "lakeformation",
+            "passed": True,
+            "message": f"Lake Formation API reachable in {region} (permissions checked separately).",
+        }
+    except (EndpointConnectionError, ConnectTimeoutError) as e:
+        return {
+            "endpoint": "lakeformation",
+            "passed": False,
+            "message": (
+                f"Cannot reach Lake Formation in {region}: {e}. "
+                "Ensure the run uses networking_mode=VPC with NAT Gateway access, "
+                "or add a com.amazonaws.{region}.lakeformation VPC interface endpoint."
+            ),
+        }
+    except Exception as e:
+        return {
+            "endpoint": "lakeformation",
+            "passed": False,
+            "message": f"Lake Formation connectivity check failed: {e}",
+        }
+
+
+def check_s3tables_connectivity(region: str) -> dict:
+    """
+    Check connectivity to the S3 Tables REST API endpoint.
+
+    S3 Tables uses a dedicated REST endpoint at
+    https://s3tables.{region}.amazonaws.com/iceberg for Iceberg catalog
+    operations. This endpoint is NOT accessible in HealthOmics RESTRICTED
+    networking mode.
+    """
+    endpoint = f"s3tables.{region}.amazonaws.com"
+    try:
+        # TCP connectivity check on port 443
+        sock = socket.create_connection((endpoint, 443), timeout=CONNECT_TIMEOUT)
+        sock.close()
+        return {
+            "endpoint": "s3tables",
+            "passed": True,
+            "message": f"S3 Tables REST endpoint reachable at {endpoint}.",
+        }
+    except (socket.timeout, socket.gaierror, OSError) as e:
+        return {
+            "endpoint": "s3tables",
+            "passed": False,
+            "message": (
+                f"Cannot reach S3 Tables endpoint {endpoint}: {e}. "
+                "S3 Tables requires VPC-connected workflow runs. "
+                "Ensure the run uses networking_mode=VPC with a configuration "
+                "that has private subnets routed through a NAT Gateway."
+            ),
+        }
+
+
+def check_s3_connectivity(region: str) -> dict:
+    """
+    Check connectivity to Amazon S3.
+
+    S3 is required for reading VCF input files and writing Iceberg data files.
+    In HealthOmics RESTRICTED mode, same-region S3 is accessible by default.
+    In VPC mode, S3 access goes through the VPC — use a Gateway endpoint for
+    best performance and cost.
+    """
+    try:
+        s3 = boto3.client("s3", region_name=region)
+        # Lightweight probe — list buckets (limit 1)
+        s3.list_buckets(MaxBuckets=1)
+        return {
+            "endpoint": "s3",
+            "passed": True,
+            "message": f"S3 reachable in {region}.",
+        }
+    except ClientError:
+        # Access denied still means the endpoint is reachable
+        return {
+            "endpoint": "s3",
+            "passed": True,
+            "message": f"S3 reachable in {region} (permissions checked separately).",
+        }
+    except (EndpointConnectionError, ConnectTimeoutError) as e:
+        return {
+            "endpoint": "s3",
+            "passed": False,
+            "message": (
+                f"Cannot reach S3 in {region}: {e}. "
+                "Add a com.amazonaws.{region}.s3 Gateway VPC endpoint for "
+                "best performance and cost."
+            ),
+        }
+    except Exception as e:
+        return {
+            "endpoint": "s3",
+            "passed": False,
+            "message": f"S3 connectivity check failed: {e}",
+        }
+
+
+def check_connectivity(catalog_config: dict) -> dict:
+    """
+    Run all connectivity checks relevant to the catalog type.
+
+    Args:
+        catalog_config: Full catalog configuration dict (from setup_catalog output)
+
+    Returns:
+        dict with keys: status, catalog_type, checks, passed, failures, guidance
+    """
+    catalog_type = catalog_config.get("catalog_type", "")
+    inner_config = catalog_config.get("catalog_config", catalog_config)
+    region = inner_config.get("region") or inner_config.get("client.region", "us-east-1")
+
+    checks = []
+
+    # STS is always required
+    checks.append(check_sts_connectivity())
+
+    if catalog_type == "vanilla":
+        checks.append(check_glue_connectivity(region))
+        checks.append(check_lakeformation_connectivity(region))
+        checks.append(check_s3_connectivity(region))
+    elif catalog_type == "s3tables":
+        checks.append(check_s3tables_connectivity(region))
+        checks.append(check_s3_connectivity(region))
+    else:
+        # Unknown type — check everything
+        checks.append(check_glue_connectivity(region))
+        checks.append(check_s3tables_connectivity(region))
+        checks.append(check_s3_connectivity(region))
+
+    failures = [c for c in checks if not c["passed"]]
+    passed = len(failures) == 0
+
+    guidance = None
+    if not passed:
+        guidance = (
+            "This workflow requires VPC-connected runs in AWS HealthOmics. "
+            "When starting the run, set networking_mode=VPC and provide a "
+            "configuration_name that references an ACTIVE HealthOmics Configuration "
+            "with private subnets routed through a NAT Gateway. "
+            "See the HealthOmics VPC documentation for setup instructions."
+        )
+
+    return {
+        "status": "passed" if passed else "failed",
+        "catalog_type": catalog_type,
+        "region": region,
+        "checks": checks,
+        "passed": passed,
+        "failures": [f["message"] for f in failures],
+        "guidance": guidance,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check network connectivity for HealthOmics VCF Loader"
+    )
+    parser.add_argument(
+        "--catalog-config", required=True,
+        help="Path to catalog_config.json from setupCatalog"
+    )
+    parser.add_argument("--output", help="Output JSON file")
+
+    args = parser.parse_args()
+
+    # Load catalog config
+    with open(args.catalog_config) as f:
+        config = json.load(f)
+
+    result = check_connectivity(config)
+
+    output_json = json.dumps(result, indent=2)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output_json)
+
+    # Print report
+    print(output_json)
+
+    if not result["passed"]:
+        print("\n=== CONNECTIVITY FAILURES ===", file=sys.stderr)
+        for msg in result["failures"]:
+            print(f"  ✗ {msg}", file=sys.stderr)
+        if result.get("guidance"):
+            print(f"\n  ℹ {result['guidance']}", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/check_permissions.py
+++ b/templates/gff3-to-iceberg/check_permissions.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Permissions checker for HealthOmics GFF3 Annotation Loader workflow.
+
+Probes AWS permissions before table initialization. Checks vary by catalog type:
+- Glue (vanilla S3): Glue API, Lake Formation, S3 write
+- S3 Tables: s3tables API
+"""
+
+import sys
+import json
+import argparse
+import boto3
+from botocore.exceptions import ClientError
+
+
+SCHEMA_NAMESPACES = {
+    "1": "annotation_db",
+    "2": "annotation_db_2",
+}
+
+
+def get_caller_identity():
+    sts = boto3.client("sts")
+    identity = sts.get_caller_identity()
+    return {"arn": identity["Arn"], "account": identity["Account"]}
+
+
+def check_glue_access(region, database):
+    glue = boto3.client("glue", region_name=region)
+    try:
+        glue.get_database(Name=database)
+        return {"check": "glue_access", "passed": True,
+                "message": f"Glue database '{database}' exists and is accessible."}
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "EntityNotFoundException":
+            try:
+                glue.get_databases(MaxResults=1)
+                return {"check": "glue_access", "passed": True,
+                        "message": f"Glue database '{database}' does not exist yet but Glue API is accessible."}
+            except ClientError as e2:
+                return {"check": "glue_access", "passed": False, "message": f"Cannot list Glue databases: {e2}"}
+        elif code == "AccessDeniedException":
+            return {"check": "glue_access", "passed": False,
+                    "message": f"Access denied to Glue database '{database}'."}
+        return {"check": "glue_access", "passed": False, "message": f"Glue API error: {e}"}
+
+
+def check_lakeformation_settings(region):
+    lf = boto3.client("lakeformation", region_name=region)
+    try:
+        settings = lf.get_data_lake_settings()["DataLakeSettings"]
+    except ClientError as e:
+        return {"check": "lakeformation_settings", "passed": False,
+                "message": f"Cannot read Lake Formation settings: {e}"}
+    create_db = settings.get("CreateDatabaseDefaultPermissions", [{}])
+    create_tbl = settings.get("CreateTableDefaultPermissions", [{}])
+    iam_only = len(create_db) == 0 and len(create_tbl) == 0
+    return {
+        "check": "lakeformation_settings", "passed": True,
+        "governed": not iam_only,
+        "message": "Lake Formation is in IAM-only mode." if iam_only
+                   else "Lake Formation is governing the Glue catalog."
+    }
+
+
+def check_s3tables_access(destination):
+    parts = destination.split(":")
+    region = parts[3]
+    s3tables = boto3.client("s3tables", region_name=region)
+    try:
+        s3tables.list_namespaces(tableBucketARN=destination, maxNamespaces=1)
+        return {"check": "s3tables_access", "passed": True,
+                "message": "S3 Tables API is accessible for the given bucket."}
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code == "AccessDeniedException":
+            return {"check": "s3tables_access", "passed": False,
+                    "message": "Access denied to S3 Tables."}
+        return {"check": "s3tables_access", "passed": False, "message": f"S3 Tables API error: {e}"}
+    except Exception as e:
+        return {"check": "s3tables_access", "passed": False, "message": f"S3 Tables check failed: {e}"}
+
+
+def check_s3_write(destination):
+    if not destination.startswith("s3://"):
+        return {"check": "s3_write", "passed": True, "message": "Not an S3 path, skipped."}
+    bucket = destination[5:].split("/")[0]
+    prefix = destination[5:].split("/", 1)[1] if "/" in destination[5:] else ""
+    test_key = f"{prefix}.healthomics-permission-check".strip("/")
+    s3 = boto3.client("s3")
+    try:
+        s3.put_object(Bucket=bucket, Key=test_key, Body=b"")
+        s3.delete_object(Bucket=bucket, Key=test_key)
+        return {"check": "s3_write", "passed": True,
+                "message": f"S3 write access confirmed for s3://{bucket}/{prefix}"}
+    except ClientError as e:
+        return {"check": "s3_write", "passed": False, "message": f"S3 write check failed: {e}"}
+
+
+def check_permissions(catalog_type, destination, schema, namespace=None):
+    ns = namespace or SCHEMA_NAMESPACES.get(schema, "annotation_db")
+    identity = get_caller_identity()
+    checks = []
+
+    if catalog_type == "vanilla":
+        session = boto3.session.Session()
+        region = session.region_name or "us-east-1"
+        checks.append(check_glue_access(region, ns))
+        lf_settings = check_lakeformation_settings(region)
+        checks.append(lf_settings)
+        checks.append(check_s3_write(destination))
+    elif catalog_type == "s3tables":
+        checks.append(check_s3tables_access(destination))
+
+    failures = [c for c in checks if not c["passed"]]
+    return {
+        "status": "passed" if not failures else "failed",
+        "identity": identity, "catalog_type": catalog_type, "namespace": ns,
+        "checks": checks, "passed": len(failures) == 0,
+        "failures": [f["message"] for f in failures],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check permissions for GFF3 Annotation Loader")
+    parser.add_argument("--catalog-config", required=True, help="Path to catalog_config.json")
+    parser.add_argument("--schema", required=True, help="Schema selection (1 or 2)")
+    parser.add_argument("--namespace", help="Iceberg namespace override")
+    parser.add_argument("--output", help="Output JSON file")
+    args = parser.parse_args()
+
+    with open(args.catalog_config) as f:
+        config = json.load(f)
+
+    result = check_permissions(config["catalog_type"], config["destination"], args.schema, args.namespace)
+    output_json = json.dumps(result, indent=2)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output_json)
+    print(output_json)
+    if not result["passed"]:
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/generate_summary.py
+++ b/templates/gff3-to-iceberg/generate_summary.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate workflow execution summary JSON for GFF3 Annotation Loader."""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+
+def parse_timestamp(ts):
+    try:
+        return datetime.fromisoformat(ts.replace('Z', '+00:00'))
+    except ValueError as e:
+        raise ValueError(f"Invalid timestamp: {ts}") from e
+
+
+def calculate_duration(start, end):
+    return int((parse_timestamp(end) - parse_timestamp(start)).total_seconds())
+
+
+def build_summary(gff3_file, schema, destination, namespace, catalog_type,
+                  tables_created, features_loaded, sources_loaded,
+                  start_time, end_time, batch_size=100000,
+                  relationships_loaded=0, batches_processed=0, table_locations=None):
+    duration = calculate_duration(start_time, end_time)
+    summary = {
+        "workflow": "healthomics-gff3-loader",
+        "version": "1.0.0",
+        "execution": {
+            "start_time": start_time, "end_time": end_time,
+            "duration_seconds": duration,
+        },
+        "inputs": {
+            "gff3_file": gff3_file, "schema": schema,
+            "destination": destination, "namespace": namespace,
+            "batch_size": batch_size,
+        },
+        "results": {
+            "catalog_type": catalog_type, "tables_created": tables_created,
+            "features_loaded": features_loaded, "sources_loaded": sources_loaded,
+        },
+    }
+    if relationships_loaded > 0:
+        summary["results"]["relationships_loaded"] = relationships_loaded
+    if batches_processed > 0:
+        summary["results"]["batches_processed"] = batches_processed
+    if table_locations:
+        summary["table_locations"] = table_locations
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate GFF3 loader summary')
+    parser.add_argument('--gff3-file', required=True)
+    parser.add_argument('--schema', required=True)
+    parser.add_argument('--destination', required=True)
+    parser.add_argument('--namespace', required=True)
+    parser.add_argument('--catalog-type', required=True)
+    parser.add_argument('--tables-created', required=True)
+    parser.add_argument('--features-loaded', type=int, required=True)
+    parser.add_argument('--sources-loaded', type=int, required=True)
+    parser.add_argument('--start-time', required=True)
+    parser.add_argument('--end-time', required=True)
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--batch-size', type=int, default=100000)
+    parser.add_argument('--relationships-loaded', type=int, default=0)
+    parser.add_argument('--batches-processed', type=int, default=0)
+    parser.add_argument('--table-locations', help='JSON string of table locations')
+    args = parser.parse_args()
+
+    try:
+        tables_created = [t.strip() for t in args.tables_created.split(',') if t.strip()]
+        table_locations = json.loads(args.table_locations) if args.table_locations else None
+        summary = build_summary(
+            args.gff3_file, args.schema, args.destination, args.namespace,
+            args.catalog_type, tables_created, args.features_loaded,
+            args.sources_loaded, args.start_time, args.end_time,
+            args.batch_size, args.relationships_loaded, args.batches_processed,
+            table_locations)
+        with open(args.output, 'w') as f:
+            json.dump(summary, f, indent=2)
+        print(json.dumps(summary, indent=2))
+        return 0
+    except Exception as e:
+        print(f"Error generating summary: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/templates/gff3-to-iceberg/initialize_tables.py
+++ b/templates/gff3-to-iceberg/initialize_tables.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Table initialization module for HealthOmics GFF3 Annotation Loader workflow.
+
+Creates Iceberg tables if they don't exist based on the selected schema.
+"""
+
+import sys
+import json
+import argparse
+import importlib
+from pyiceberg.catalog import load_catalog
+from utils import create_namespace
+
+
+SCHEMA_NAMESPACES = {
+    '1': 'annotation_db',
+    '2': 'annotation_db_2',
+}
+
+
+def load_schema_module(schema):
+    if schema not in ['1', '2']:
+        raise ValueError(f"Invalid schema: {schema}. Must be 1 or 2")
+    return importlib.import_module(f"schema_{schema}")
+
+
+def connect_to_catalog(catalog_config):
+    catalog_type = catalog_config.get('type')
+    if not catalog_type:
+        raise ValueError("Catalog configuration missing 'type' field")
+    config_params = {k: v for k, v in catalog_config.items() if k != 'namespace'}
+    catalog_name = 's3tables' if catalog_type == 'rest' else 'glue'
+    return load_catalog(catalog_name, **config_params)
+
+
+def initialize_tables(catalog_config, schema, namespace=None):
+    schema_module = load_schema_module(schema)
+
+    if not namespace:
+        namespace = SCHEMA_NAMESPACES.get(schema)
+        if not namespace:
+            raise ValueError(f"No default namespace for schema {schema}")
+
+    catalog = connect_to_catalog(catalog_config)
+
+    try:
+        create_namespace(catalog, namespace)
+    except Exception as e:
+        print(f"Namespace creation: {e}")
+
+    # Determine expected tables
+    if schema == '1':
+        expected_tables = ['features', 'sources', 'feature_relationships']
+    elif schema == '2':
+        expected_tables = ['genomic_annotations']
+    else:
+        raise ValueError(f"Invalid schema: {schema}")
+
+    tables_created = []
+    tables_existing = []
+    table_metadata = {}
+
+    for table_name in expected_tables:
+        table_identifier = f"{namespace}.{table_name}"
+        if catalog.table_exists(table_identifier):
+            print(f"Table {table_identifier} already exists.")
+            tables_existing.append(table_name)
+            table = catalog.load_table(table_identifier)
+            table_metadata[table_name] = {
+                'location': table.location(), 'status': 'existing'
+            }
+
+    if len(tables_existing) < len(expected_tables):
+        print(f"Creating missing tables in namespace {namespace}...")
+        created_tables = schema_module.create_schema_tables(catalog, namespace)
+        for table_name, table in created_tables.items():
+            if table_name not in tables_existing:
+                tables_created.append(table_name)
+                table_metadata[table_name] = {
+                    'location': table.location(), 'status': 'created'
+                }
+
+    return {
+        'status': 'success', 'schema': schema, 'namespace': namespace,
+        'tables_created': tables_created, 'tables_existing': tables_existing,
+        'table_metadata': table_metadata, 'all_tables': expected_tables,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Initialize Iceberg tables for GFF3 Annotation Loader')
+    parser.add_argument('--catalog-config', required=True, help='Path to catalog configuration JSON')
+    parser.add_argument('--schema', required=True, choices=['1', '2'], help='Schema selection')
+    parser.add_argument('--namespace', help='Iceberg namespace override')
+    parser.add_argument('--output', help='Output JSON file')
+    args = parser.parse_args()
+
+    try:
+        with open(args.catalog_config, 'r') as f:
+            catalog_data = json.load(f)
+        catalog_config = catalog_data.get('catalog_config', catalog_data)
+        result = initialize_tables(catalog_config, args.schema, args.namespace)
+        output_json = json.dumps(result, indent=2)
+        if args.output:
+            with open(args.output, 'w') as f:
+                f.write(output_json)
+            print(f"Table initialization successful. Results written to {args.output}")
+        else:
+            print(output_json)
+        sys.exit(0)
+    except Exception as e:
+        error_result = {'status': 'error', 'error': str(e), 'error_type': type(e).__name__}
+        output_json = json.dumps(error_result, indent=2)
+        if args.output:
+            with open(args.output, 'w') as f:
+                f.write(output_json)
+        print(output_json, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/gff3-to-iceberg/load_gff3_schema1.py
+++ b/templates/gff3-to-iceberg/load_gff3_schema1.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+Load GFF3 files into the annotation_db tables created by schema_1.py.
+
+Parses GFF3 files and loads data into three Iceberg tables:
+  - features
+  - sources
+  - feature_relationships
+"""
+
+import argparse
+import os
+import sys
+import gzip
+import pyarrow as pa
+from urllib.parse import unquote
+from pyiceberg.exceptions import NoSuchTableError
+from utils import load_s3_tables_catalog, retry_operation
+import boto3
+from io import TextIOWrapper
+
+# Configuration
+NAMESPACE = "annotation_db"
+FEATURES_TABLE = "features"
+SOURCES_TABLE = "sources"
+RELATIONSHIPS_TABLE = "feature_relationships"
+BATCH_SIZE = 100000
+
+
+def parse_s3_uri(s3_uri):
+    """Parse S3 URI and return bucket and key."""
+    if not s3_uri.startswith('s3://'):
+        raise ValueError(f"Invalid S3 URI format: {s3_uri}")
+    s3_parts = s3_uri[5:].split('/', 1)
+    if len(s3_parts) != 2 or not s3_parts[0] or not s3_parts[1]:
+        raise ValueError(f"Invalid S3 URI — missing bucket or key: {s3_uri}")
+    return s3_parts[0], s3_parts[1]
+
+
+def get_tables():
+    """Get the existing tables or fail if they don't exist."""
+    catalog = load_s3_tables_catalog(bucket_arn)
+
+    try:
+        namespaces = [ns[0] for ns in catalog.list_namespaces()]
+        if NAMESPACE not in namespaces:
+            print(f"Error: Namespace '{NAMESPACE}' does not exist.")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error checking namespaces: {e}")
+        sys.exit(1)
+
+    tables = {}
+    for table_name in [FEATURES_TABLE, SOURCES_TABLE, RELATIONSHIPS_TABLE]:
+        table_identifier = f"{NAMESPACE}.{table_name}"
+        try:
+            tables[table_name] = catalog.load_table(table_identifier)
+        except NoSuchTableError:
+            print(f"Error: Table '{table_identifier}' does not exist.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error loading table {table_identifier}: {e}")
+            sys.exit(1)
+
+    return tables
+
+
+def open_gff3_file(file_path):
+    """Open a GFF3 file, handling local files, S3 URIs, and gzip."""
+    if file_path.startswith('s3://'):
+        bucket, key = parse_s3_uri(file_path)
+        s3_client = boto3.client('s3')
+        response = s3_client.get_object(Bucket=bucket, Key=key)
+        if file_path.endswith('.gz'):
+            return TextIOWrapper(gzip.GzipFile(fileobj=response['Body']))
+        else:
+            return TextIOWrapper(response['Body'])
+    else:
+        if file_path.endswith('.gz'):
+            return gzip.open(file_path, 'rt')
+        else:
+            return open(file_path, 'r')
+
+
+# Reserved GFF3 attributes that get extracted into dedicated columns
+RESERVED_ATTRIBUTES = {'ID', 'Name', 'Parent', 'Dbxref', 'Ontology_term', 'Is_circular'}
+
+
+def parse_gff3_attributes(attr_str):
+    """Parse GFF3 column 9 attributes with URL-decoding.
+
+    Returns a dict of all attributes. Reserved keys are included
+    so callers can extract them before storing the remainder.
+    """
+    if attr_str == '.' or not attr_str.strip():
+        return {}
+
+    attrs = {}
+    for item in attr_str.split(';'):
+        item = item.strip()
+        if not item:
+            continue
+        if '=' in item:
+            key, value = item.split('=', 1)
+            attrs[unquote(key)] = unquote(value)
+        else:
+            attrs[unquote(item)] = 'true'
+    return attrs
+
+
+def parse_gff3_header(gff3_file):
+    """Parse GFF3 header directives. Returns (directives, first_data_line).
+
+    directives is a list of (key, value) tuples for ## lines.
+    first_data_line is the first non-comment, non-empty line (or None).
+    """
+    directives = []
+    first_data_line = None
+
+    for line in gff3_file:
+        line = line.rstrip('\n\r')
+        if not line or line.startswith('###'):
+            continue
+        if line.startswith('##'):
+            parts = line[2:].strip().split(None, 1)
+            key = parts[0] if parts else ''
+            value = parts[1] if len(parts) > 1 else ''
+            directives.append((key, value))
+            continue
+        if line.startswith('#'):
+            continue
+        # First data line
+        first_data_line = line
+        break
+
+    return directives, first_data_line
+
+
+def process_gff3_batch(batch_lines):
+    """Process a batch of GFF3 data lines.
+
+    Returns dicts of PyArrow arrays for features and feature_relationships,
+    plus a set of source names encountered.
+    """
+    # Features columns
+    feature_id_list = []
+    seqid_list = []
+    source_list = []
+    type_list = []
+    start_list = []
+    end_list = []
+    score_list = []
+    strand_list = []
+    phase_list = []
+    name_list = []
+    dbxref_list = []
+    ontology_term_list = []
+    is_circular_list = []
+    attributes_list = []
+
+    # Relationships columns
+    rel_child_id_list = []
+    rel_parent_id_list = []
+    rel_seqid_list = []
+    rel_child_type_list = []
+    rel_parent_type_list = []
+
+    # Track sources and parent types for relationship enrichment
+    sources_seen = set()
+    feature_types = {}  # feature_id -> type, built during this batch
+
+    for line in batch_lines:
+        fields = line.split('\t')
+        if len(fields) < 9:
+            print(f"Warning: Skipping malformed GFF3 line (< 9 fields): {line[:80]}")
+            continue
+
+        seqid = unquote(fields[0])
+        source = unquote(fields[1])
+        feat_type = unquote(fields[2])
+
+        try:
+            start = int(fields[3])
+            end = int(fields[4])
+        except ValueError:
+            print(f"Warning: Invalid start/end in GFF3 line: {line[:80]}")
+            continue
+
+        score = None
+        if fields[5] != '.':
+            try:
+                score = float(fields[5])
+            except ValueError:
+                pass
+
+        strand = fields[6] if fields[6] != '.' else None
+        phase = fields[7] if fields[7] != '.' else None
+
+        # Parse attributes
+        attrs = parse_gff3_attributes(fields[8])
+
+        feature_id = attrs.get('ID', f"{seqid}:{feat_type}:{start}-{end}")
+        name = attrs.get('Name')
+        parent_str = attrs.get('Parent')
+        dbxref = attrs.get('Dbxref')
+        ontology_term = attrs.get('Ontology_term')
+        is_circular = attrs.get('Is_circular', '').lower() == 'true' if 'Is_circular' in attrs else None
+
+        # Build remaining attributes map (exclude reserved keys)
+        remaining_attrs = {k: v for k, v in attrs.items() if k not in RESERVED_ATTRIBUTES}
+
+        # Track
+        sources_seen.add(source)
+        feature_types[feature_id] = feat_type
+
+        # Append feature data
+        feature_id_list.append(feature_id)
+        seqid_list.append(seqid)
+        source_list.append(source)
+        type_list.append(feat_type)
+        start_list.append(start)
+        end_list.append(end)
+        score_list.append(score)
+        strand_list.append(strand)
+        phase_list.append(phase)
+        name_list.append(name)
+        dbxref_list.append(dbxref)
+        ontology_term_list.append(ontology_term)
+        is_circular_list.append(is_circular)
+        attributes_list.append(remaining_attrs)
+
+        # Build relationship rows (one per parent)
+        if parent_str:
+            parent_ids = [p.strip() for p in parent_str.split(',')]
+            for pid in parent_ids:
+                rel_child_id_list.append(feature_id)
+                rel_parent_id_list.append(pid)
+                rel_seqid_list.append(seqid)
+                rel_child_type_list.append(feat_type)
+                rel_parent_type_list.append(feature_types.get(pid))
+
+    # Convert to PyArrow arrays
+    features_arrays = {
+        'feature_id': pa.array(feature_id_list, type=pa.string()),
+        'seqid': pa.array(seqid_list, type=pa.string()),
+        'source': pa.array(source_list, type=pa.string()),
+        'type': pa.array(type_list, type=pa.string()),
+        'start': pa.array(start_list, type=pa.int64()),
+        'end': pa.array(end_list, type=pa.int64()),
+        'score': pa.array(score_list, type=pa.float64()),
+        'strand': pa.array(strand_list, type=pa.string()),
+        'phase': pa.array(phase_list, type=pa.string()),
+        'name': pa.array(name_list, type=pa.string()),
+        'dbxref': pa.array(dbxref_list, type=pa.string()),
+        'ontology_term': pa.array(ontology_term_list, type=pa.string()),
+        'is_circular': pa.array(is_circular_list, type=pa.bool_()),
+        'attributes': pa.array(
+            [{str(k): str(v) for k, v in d.items()} for d in attributes_list],
+            type=pa.map_(pa.string(), pa.string())),
+    }
+
+    relationships_arrays = None
+    if rel_child_id_list:
+        relationships_arrays = {
+            'child_id': pa.array(rel_child_id_list, type=pa.string()),
+            'parent_id': pa.array(rel_parent_id_list, type=pa.string()),
+            'seqid': pa.array(rel_seqid_list, type=pa.string()),
+            'child_type': pa.array(rel_child_type_list, type=pa.string()),
+            'parent_type': pa.array(rel_parent_type_list, type=pa.string()),
+        }
+
+    return features_arrays, relationships_arrays, sources_seen
+
+
+def write_to_iceberg(table, data_arrays, pyarrow_schema, table_name):
+    """Write data arrays to an Iceberg table with retry logic."""
+    columns = [data_arrays[field.name] for field in pyarrow_schema]
+    arrow_table = pa.Table.from_arrays(columns, schema=pyarrow_schema)
+
+    print(f"Writing {len(arrow_table)} rows to {NAMESPACE}.{table_name}...")
+
+    def is_commit_failed(e):
+        return "CommitFailedException" in str(e) and "branch main has changed" in str(e)
+
+    retry_operation(
+        table.append,
+        arrow_table,
+        max_retries=5,
+        retry_condition=is_commit_failed,
+    )
+    print(f"Successfully wrote {len(arrow_table)} rows to {NAMESPACE}.{table_name}")
+
+
+def process_gff3_file(gff3_path, tables=None, pyarrow_schemas=None):
+    """Process a GFF3 file in batches and write to Iceberg tables."""
+    print(f"Processing GFF3 file: {gff3_path}")
+
+    all_sources = set()
+
+    with open_gff3_file(gff3_path) as gff3_file:
+        directives, first_line = parse_gff3_header(gff3_file)
+
+        # Log directives
+        for key, value in directives:
+            print(f"  Directive: ##{key} {value}")
+
+        # Process data lines in batches
+        batch_lines = []
+        if first_line:
+            batch_lines.append(first_line)
+
+        records_processed = 0
+
+        for line in gff3_file:
+            line = line.rstrip('\n\r')
+            if not line or line.startswith('#'):
+                continue
+            # FASTA section terminates GFF3 features
+            if line.startswith('>'):
+                break
+
+            batch_lines.append(line)
+
+            if len(batch_lines) >= BATCH_SIZE:
+                feat_arrays, rel_arrays, sources = process_gff3_batch(batch_lines)
+                all_sources.update(sources)
+
+                if tables and pyarrow_schemas:
+                    write_to_iceberg(tables[FEATURES_TABLE], feat_arrays,
+                                     pyarrow_schemas[FEATURES_TABLE], FEATURES_TABLE)
+                    if rel_arrays:
+                        write_to_iceberg(tables[RELATIONSHIPS_TABLE], rel_arrays,
+                                         pyarrow_schemas[RELATIONSHIPS_TABLE], RELATIONSHIPS_TABLE)
+
+                records_processed += len(batch_lines)
+                print(f"Processed {records_processed} records so far...")
+                batch_lines = []
+
+        # Remaining records
+        if batch_lines:
+            feat_arrays, rel_arrays, sources = process_gff3_batch(batch_lines)
+            all_sources.update(sources)
+
+            if tables and pyarrow_schemas:
+                write_to_iceberg(tables[FEATURES_TABLE], feat_arrays,
+                                 pyarrow_schemas[FEATURES_TABLE], FEATURES_TABLE)
+                if rel_arrays:
+                    write_to_iceberg(tables[RELATIONSHIPS_TABLE], rel_arrays,
+                                     pyarrow_schemas[RELATIONSHIPS_TABLE], RELATIONSHIPS_TABLE)
+
+            records_processed += len(batch_lines)
+
+        # Write sources
+        if all_sources and tables and pyarrow_schemas:
+            sources_arrays = {
+                'source_name': pa.array(sorted(all_sources), type=pa.string()),
+                'description': pa.array([None] * len(all_sources), type=pa.string()),
+            }
+            write_to_iceberg(tables[SOURCES_TABLE], sources_arrays,
+                             pyarrow_schemas[SOURCES_TABLE], SOURCES_TABLE)
+
+        print(f"Processed {records_processed} records total from {gff3_path}")
+
+
+def main():
+    global bucket_arn, NAMESPACE, BATCH_SIZE
+
+    parser = argparse.ArgumentParser(description='Load GFF3 files into Iceberg tables (Schema 1)')
+    parser.add_argument('gff3_files', nargs='+', help='GFF3 file paths to load (local or s3://)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    parser.add_argument('--namespace', default=NAMESPACE, help=f'Iceberg namespace (default: {NAMESPACE})')
+    parser.add_argument('--batch-size', type=int, default=BATCH_SIZE,
+                        help=f'Records per batch (default: {BATCH_SIZE})')
+    args = parser.parse_args()
+
+    bucket_arn = args.bucket_arn
+    NAMESPACE = args.namespace
+    BATCH_SIZE = args.batch_size
+
+    print("Getting tables...")
+    tables = get_tables()
+    pyarrow_schemas = {
+        table_name: table.schema().as_arrow()
+        for table_name, table in tables.items()
+    }
+
+    for gff3_file in args.gff3_files:
+        file_exists = True
+        if gff3_file.startswith('s3://'):
+            try:
+                bucket, key = parse_s3_uri(gff3_file)
+                s3_client = boto3.client('s3')
+                s3_client.head_object(Bucket=bucket, Key=key)
+            except Exception as e:
+                file_exists = False
+                print(f"Error: S3 file not found: {gff3_file} — {e}")
+        else:
+            file_exists = os.path.exists(gff3_file)
+            if not file_exists:
+                print(f"Error: Local file not found: {gff3_file}")
+
+        if not file_exists:
+            continue
+
+        try:
+            process_gff3_file(gff3_file, tables, pyarrow_schemas)
+        except Exception as e:
+            print(f"Error processing file {gff3_file}: {e}")
+            import traceback
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/load_gff3_schema2.py
+++ b/templates/gff3-to-iceberg/load_gff3_schema2.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Load GFF3 files into the annotation_db_2.genomic_annotations Iceberg table
+created by schema_2.py.
+
+Denormalized: one row per feature with parent IDs embedded as a list.
+"""
+
+import argparse
+import os
+import sys
+import gzip
+import pyarrow as pa
+from urllib.parse import unquote
+from pyiceberg.exceptions import NoSuchTableError
+from utils import load_s3_tables_catalog, retry_operation
+import boto3
+from io import TextIOWrapper
+
+# Configuration
+NAMESPACE = "annotation_db_2"
+TABLE_NAME = "genomic_annotations"
+BATCH_SIZE = 100000
+
+# Reserved GFF3 attributes extracted into dedicated columns
+RESERVED_ATTRIBUTES = {'ID', 'Name', 'Parent', 'Dbxref', 'Ontology_term', 'Is_circular'}
+
+
+def parse_s3_uri(s3_uri):
+    """Parse S3 URI and return bucket and key."""
+    if not s3_uri.startswith('s3://'):
+        raise ValueError(f"Invalid S3 URI format: {s3_uri}")
+    s3_parts = s3_uri[5:].split('/', 1)
+    if len(s3_parts) != 2 or not s3_parts[0] or not s3_parts[1]:
+        raise ValueError(f"Invalid S3 URI — missing bucket or key: {s3_uri}")
+    return s3_parts[0], s3_parts[1]
+
+
+def get_table():
+    """Get the existing table or fail if it doesn't exist."""
+    catalog = load_s3_tables_catalog(bucket_arn)
+
+    try:
+        namespaces = [ns[0] for ns in catalog.list_namespaces()]
+        if NAMESPACE not in namespaces:
+            print(f"Error: Namespace '{NAMESPACE}' does not exist.")
+            sys.exit(1)
+    except Exception as e:
+        print(f"Error checking namespaces: {e}")
+        sys.exit(1)
+
+    table_identifier = f"{NAMESPACE}.{TABLE_NAME}"
+    try:
+        return catalog.load_table(table_identifier)
+    except NoSuchTableError:
+        print(f"Error: Table '{table_identifier}' does not exist.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error loading table: {e}")
+        sys.exit(1)
+
+
+def open_gff3_file(file_path):
+    """Open a GFF3 file, handling local files, S3 URIs, and gzip."""
+    if file_path.startswith('s3://'):
+        bucket, key = parse_s3_uri(file_path)
+        s3_client = boto3.client('s3')
+        response = s3_client.get_object(Bucket=bucket, Key=key)
+        if file_path.endswith('.gz'):
+            return TextIOWrapper(gzip.GzipFile(fileobj=response['Body']))
+        else:
+            return TextIOWrapper(response['Body'])
+    else:
+        if file_path.endswith('.gz'):
+            return gzip.open(file_path, 'rt')
+        else:
+            return open(file_path, 'r')
+
+
+def parse_gff3_attributes(attr_str):
+    """Parse GFF3 column 9 attributes with URL-decoding."""
+    if attr_str == '.' or not attr_str.strip():
+        return {}
+
+    attrs = {}
+    for item in attr_str.split(';'):
+        item = item.strip()
+        if not item:
+            continue
+        if '=' in item:
+            key, value = item.split('=', 1)
+            attrs[unquote(key)] = unquote(value)
+        else:
+            attrs[unquote(item)] = 'true'
+    return attrs
+
+
+def parse_gff3_header(gff3_file):
+    """Parse GFF3 header directives. Returns (directives, first_data_line)."""
+    directives = []
+    first_data_line = None
+
+    for line in gff3_file:
+        line = line.rstrip('\n\r')
+        if not line or line.startswith('###'):
+            continue
+        if line.startswith('##'):
+            parts = line[2:].strip().split(None, 1)
+            key = parts[0] if parts else ''
+            value = parts[1] if len(parts) > 1 else ''
+            directives.append((key, value))
+            continue
+        if line.startswith('#'):
+            continue
+        first_data_line = line
+        break
+
+    return directives, first_data_line
+
+
+def process_gff3_batch(batch_lines):
+    """Process a batch of GFF3 data lines into PyArrow arrays."""
+    feature_id_list = []
+    seqid_list = []
+    source_list = []
+    type_list = []
+    start_list = []
+    end_list = []
+    score_list = []
+    strand_list = []
+    phase_list = []
+    name_list = []
+    parent_ids_list = []
+    dbxref_list = []
+    ontology_term_list = []
+    is_circular_list = []
+    attributes_list = []
+
+    for line in batch_lines:
+        fields = line.split('\t')
+        if len(fields) < 9:
+            print(f"Warning: Skipping malformed GFF3 line (< 9 fields): {line[:80]}")
+            continue
+
+        seqid = unquote(fields[0])
+        source = unquote(fields[1])
+        feat_type = unquote(fields[2])
+
+        try:
+            start = int(fields[3])
+            end = int(fields[4])
+        except ValueError:
+            print(f"Warning: Invalid start/end in GFF3 line: {line[:80]}")
+            continue
+
+        score = None
+        if fields[5] != '.':
+            try:
+                score = float(fields[5])
+            except ValueError:
+                pass
+
+        strand = fields[6] if fields[6] != '.' else None
+        phase = fields[7] if fields[7] != '.' else None
+
+        attrs = parse_gff3_attributes(fields[8])
+
+        feature_id = attrs.get('ID', f"{seqid}:{feat_type}:{start}-{end}")
+        name = attrs.get('Name')
+        dbxref = attrs.get('Dbxref')
+        ontology_term = attrs.get('Ontology_term')
+        is_circular = attrs.get('Is_circular', '').lower() == 'true' if 'Is_circular' in attrs else None
+
+        # Parent IDs as a list
+        parent_str = attrs.get('Parent')
+        parent_ids = [p.strip() for p in parent_str.split(',')] if parent_str else []
+
+        # Remaining attributes
+        remaining_attrs = {k: v for k, v in attrs.items() if k not in RESERVED_ATTRIBUTES}
+
+        feature_id_list.append(feature_id)
+        seqid_list.append(seqid)
+        source_list.append(source)
+        type_list.append(feat_type)
+        start_list.append(start)
+        end_list.append(end)
+        score_list.append(score)
+        strand_list.append(strand)
+        phase_list.append(phase)
+        name_list.append(name)
+        parent_ids_list.append(parent_ids)
+        dbxref_list.append(dbxref)
+        ontology_term_list.append(ontology_term)
+        is_circular_list.append(is_circular)
+        attributes_list.append(remaining_attrs)
+
+    return {
+        'feature_id': pa.array(feature_id_list, type=pa.string()),
+        'seqid': pa.array(seqid_list, type=pa.string()),
+        'source': pa.array(source_list, type=pa.string()),
+        'type': pa.array(type_list, type=pa.string()),
+        'start': pa.array(start_list, type=pa.int64()),
+        'end': pa.array(end_list, type=pa.int64()),
+        'score': pa.array(score_list, type=pa.float64()),
+        'strand': pa.array(strand_list, type=pa.string()),
+        'phase': pa.array(phase_list, type=pa.string()),
+        'name': pa.array(name_list, type=pa.string()),
+        'parent_ids': pa.array(parent_ids_list, type=pa.list_(pa.string())),
+        'dbxref': pa.array(dbxref_list, type=pa.string()),
+        'ontology_term': pa.array(ontology_term_list, type=pa.string()),
+        'is_circular': pa.array(is_circular_list, type=pa.bool_()),
+        'attributes': pa.array(
+            [{str(k): str(v) for k, v in d.items()} for d in attributes_list],
+            type=pa.map_(pa.string(), pa.string())),
+    }
+
+
+def write_to_iceberg(table, data_arrays, pyarrow_schema):
+    """Write data to the Iceberg table."""
+    columns = [data_arrays[field.name] for field in pyarrow_schema]
+    arrow_table = pa.Table.from_arrays(columns, schema=pyarrow_schema)
+
+    print(f"Writing {len(arrow_table)} rows to {NAMESPACE}.{TABLE_NAME}...")
+
+    def is_commit_failed(e):
+        return "CommitFailedException" in str(e) and "branch main has changed" in str(e)
+
+    retry_operation(
+        table.append,
+        arrow_table,
+        max_retries=5,
+        retry_condition=is_commit_failed,
+    )
+    print(f"Successfully wrote {len(arrow_table)} rows to {NAMESPACE}.{TABLE_NAME}")
+
+
+def process_gff3_file(gff3_path, table=None, pyarrow_schema=None):
+    """Process a GFF3 file in batches and write to Iceberg table."""
+    print(f"Processing GFF3 file: {gff3_path}")
+
+    with open_gff3_file(gff3_path) as gff3_file:
+        directives, first_line = parse_gff3_header(gff3_file)
+
+        for key, value in directives:
+            print(f"  Directive: ##{key} {value}")
+
+        batch_lines = []
+        if first_line:
+            batch_lines.append(first_line)
+
+        records_processed = 0
+
+        for line in gff3_file:
+            line = line.rstrip('\n\r')
+            if not line or line.startswith('#'):
+                continue
+            if line.startswith('>'):
+                break
+
+            batch_lines.append(line)
+
+            if len(batch_lines) >= BATCH_SIZE:
+                data_arrays = process_gff3_batch(batch_lines)
+                if table and pyarrow_schema:
+                    write_to_iceberg(table, data_arrays, pyarrow_schema)
+                    records_processed += len(batch_lines)
+                    print(f"Processed {records_processed} records so far...")
+                else:
+                    return data_arrays
+                batch_lines = []
+
+        if batch_lines:
+            data_arrays = process_gff3_batch(batch_lines)
+            if table and pyarrow_schema:
+                write_to_iceberg(table, data_arrays, pyarrow_schema)
+                records_processed += len(batch_lines)
+                print(f"Processed {records_processed} records total.")
+                return None
+            else:
+                return data_arrays
+
+    return None
+
+
+def main():
+    global bucket_arn, NAMESPACE, TABLE_NAME, BATCH_SIZE
+
+    parser = argparse.ArgumentParser(description='Load GFF3 files into Iceberg table (Schema 2)')
+    parser.add_argument('gff3_files', nargs='+', help='GFF3 file paths to load (local or s3://)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    parser.add_argument('--namespace', default=NAMESPACE, help=f'Iceberg namespace (default: {NAMESPACE})')
+    parser.add_argument('--table', default=TABLE_NAME, help=f'Table name (default: {TABLE_NAME})')
+    parser.add_argument('--batch-size', type=int, default=BATCH_SIZE,
+                        help=f'Records per batch (default: {BATCH_SIZE})')
+    args = parser.parse_args()
+
+    bucket_arn = args.bucket_arn
+    NAMESPACE = args.namespace
+    TABLE_NAME = args.table
+    BATCH_SIZE = args.batch_size
+
+    print("Getting table...")
+    table = get_table()
+    pyarrow_schema = table.schema().as_arrow()
+
+    for gff3_file in args.gff3_files:
+        file_exists = True
+        if gff3_file.startswith('s3://'):
+            try:
+                bucket, key = parse_s3_uri(gff3_file)
+                s3_client = boto3.client('s3')
+                s3_client.head_object(Bucket=bucket, Key=key)
+            except Exception as e:
+                file_exists = False
+                print(f"Error: S3 file not found: {gff3_file} — {e}")
+        else:
+            file_exists = os.path.exists(gff3_file)
+            if not file_exists:
+                print(f"Error: Local file not found: {gff3_file}")
+
+        if not file_exists:
+            continue
+
+        try:
+            process_gff3_file(gff3_file, table, pyarrow_schema)
+        except Exception as e:
+            print(f"Error processing file {gff3_file}: {e}")
+            import traceback
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/load_gff3_wrapper.py
+++ b/templates/gff3-to-iceberg/load_gff3_wrapper.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Wrapper script to load GFF3 files into Iceberg tables.
+Accepts catalog configuration and delegates to the appropriate schema-specific loader.
+"""
+
+import argparse
+import json
+import sys
+from pyiceberg.catalog import load_catalog
+from pyiceberg.exceptions import NoSuchTableError
+
+
+def load_catalog_from_config(catalog_config):
+    catalog_type = catalog_config.get('type')
+    if catalog_type == 'rest':
+        catalog = load_catalog(
+            "s3tables", type="rest",
+            warehouse=catalog_config['warehouse'],
+            uri=catalog_config['uri'],
+            **{k: v for k, v in catalog_config.items() if k.startswith('rest.')}
+        )
+    elif catalog_type == 'glue':
+        catalog = load_catalog(
+            "glue", type="glue",
+            warehouse=catalog_config['warehouse'],
+            **{k: v for k, v in catalog_config.items() if k.startswith('client.') or k.startswith('glue.')}
+        )
+    else:
+        raise ValueError(f"Unsupported catalog type: {catalog_type}")
+    return catalog
+
+
+def get_loader_module(schema):
+    if schema == '1':
+        import load_gff3_schema1 as loader
+        namespace = "annotation_db"
+        table_names = ["features", "sources", "feature_relationships"]
+    elif schema == '2':
+        import load_gff3_schema2 as loader
+        namespace = "annotation_db_2"
+        table_names = ["genomic_annotations"]
+    else:
+        raise ValueError(f"Invalid schema: {schema}")
+    return loader, namespace, table_names
+
+
+def load_tables(catalog, namespace, table_names):
+    tables = {}
+    pyarrow_schemas = {}
+    for table_name in table_names:
+        table_identifier = f"{namespace}.{table_name}"
+        try:
+            table = catalog.load_table(table_identifier)
+            tables[table_name] = table
+            pyarrow_schemas[table_name] = table.schema().as_arrow()
+        except NoSuchTableError:
+            print(f"Error: Table '{table_identifier}' does not exist.")
+            sys.exit(1)
+        except Exception as e:
+            print(f"Error loading table {table_identifier}: {e}")
+            sys.exit(1)
+    return tables, pyarrow_schemas
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Load GFF3 files into Iceberg tables')
+    parser.add_argument('--gff3-file', required=True, help='Path to GFF3 file')
+    parser.add_argument('--catalog-config', required=True, help='Path to catalog configuration JSON')
+    parser.add_argument('--schema', required=True, choices=['1', '2'], help='Schema selection')
+    parser.add_argument('--namespace', help='Iceberg namespace override')
+    parser.add_argument('--batch-size', type=int, default=100000, help='Batch size (default: 100000)')
+    parser.add_argument('--output', default='load_stats.json', help='Output stats file')
+    args = parser.parse_args()
+
+    with open(args.catalog_config, 'r') as f:
+        catalog_data = json.load(f)
+    catalog_config = catalog_data.get('catalog_config', catalog_data)
+
+    print("Loading catalog...")
+    catalog = load_catalog_from_config(catalog_config)
+
+    print(f"Loading schema {args.schema} loader module...")
+    loader, default_namespace, table_names = get_loader_module(args.schema)
+    namespace = args.namespace if args.namespace else default_namespace
+
+    print(f"Loading tables from namespace '{namespace}'...")
+    tables, pyarrow_schemas = load_tables(catalog, namespace, table_names)
+
+    if hasattr(loader, 'NAMESPACE'):
+        loader.NAMESPACE = namespace
+    if hasattr(loader, 'BATCH_SIZE'):
+        loader.BATCH_SIZE = args.batch_size
+
+    stats = {
+        'gff3_file': args.gff3_file, 'schema': args.schema,
+        'namespace': namespace, 'batch_size': args.batch_size,
+        'features_loaded': 0, 'sources_loaded': 0,
+        'relationships_loaded': 0, 'batches_processed': 0,
+    }
+
+    original_append_funcs = {}
+
+    def create_tracking_append(table_name, original_append):
+        def tracking_append(arrow_table):
+            result = original_append(arrow_table)
+            row_count = len(arrow_table)
+            if table_name in ['features', 'genomic_annotations']:
+                stats['features_loaded'] += row_count
+                stats['batches_processed'] += 1
+            elif table_name == 'sources':
+                stats['sources_loaded'] += row_count
+            elif table_name == 'feature_relationships':
+                stats['relationships_loaded'] += row_count
+            return result
+        return tracking_append
+
+    for table_name, table in tables.items():
+        original_append_funcs[table_name] = table.append
+        table.append = create_tracking_append(table_name, table.append)
+
+    print(f"Processing GFF3 file: {args.gff3_file}")
+    try:
+        if args.schema == '1':
+            loader.process_gff3_file(
+                gff3_path=args.gff3_file, tables=tables, pyarrow_schemas=pyarrow_schemas)
+        elif args.schema == '2':
+            loader.process_gff3_file(
+                gff3_path=args.gff3_file, table=tables['genomic_annotations'],
+                pyarrow_schema=pyarrow_schemas['genomic_annotations'])
+        print("GFF3 loading completed successfully.")
+    except Exception as e:
+        print(f"Error processing GFF3 file: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+    finally:
+        for table_name, table in tables.items():
+            table.append = original_append_funcs[table_name]
+
+    with open(args.output, 'w') as f:
+        json.dump(stats, f, indent=2)
+    print(f"Statistics written to {args.output}")
+    print(json.dumps(stats, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/main.wdl
+++ b/templates/gff3-to-iceberg/main.wdl
@@ -1,0 +1,335 @@
+version 1.1
+
+## HealthOmics GFF3 Annotation Loader Workflow
+##
+## Loads GFF3 files into Apache Iceberg tables on AWS.
+## Supports S3 Tables (managed Iceberg catalog) and vanilla Iceberg with Glue catalog.
+##
+## NETWORKING: Both catalog types require VPC-connected workflow runs.
+
+workflow healthomics_gff3_loader {
+
+    meta {
+        description: "Loads GFF3 annotation files into Apache Iceberg tables on AWS."
+        author: "AWS HealthOmics"
+        version: "1.0.0"
+    }
+
+    parameter_meta {
+        gff3_file: "S3 URI to the input GFF3 file (.gff3 or .gff3.gz)"
+        schema: "Schema design to use: 1 (normalized) or 2 (denormalized)"
+        destination: "For Glue catalog use bucket/path (no s3:// prefix). For S3 Tables use the full ARN."
+        container: "ECR container image URI"
+        namespace: "Iceberg namespace. Auto-determined by schema if omitted."
+        batch_size: "Number of GFF3 records per processing batch (default: 100000)"
+    }
+
+    input {
+        File gff3_file
+        String schema
+        String destination
+        String container
+        String? namespace
+        Int batch_size = 100000
+    }
+
+    String full_destination = if sub(destination, "^arn:.*", "") == "" then destination else "s3://~{destination}"
+
+    call validate_inputs {
+        input:
+            gff3_file = gff3_file,
+            schema = schema,
+            destination = full_destination,
+            container = container
+    }
+
+    call setup_catalog {
+        input:
+            validation_result = validate_inputs.validation_json,
+            destination = full_destination,
+            namespace = namespace,
+            container = container
+    }
+
+    call check_connectivity {
+        input:
+            catalog_config = setup_catalog.catalog_json,
+            container = container
+    }
+
+    call check_permissions {
+        input:
+            catalog_config = setup_catalog.catalog_json,
+            schema = schema,
+            namespace = namespace,
+            container = container,
+            connectivity_report = check_connectivity.connectivity_json
+    }
+
+    call initialize_tables {
+        input:
+            catalog_config = setup_catalog.catalog_json,
+            schema = schema,
+            namespace = namespace,
+            container = container,
+            permissions_report = check_permissions.permissions_json
+    }
+
+    call load_gff3 {
+        input:
+            gff3_file = gff3_file,
+            catalog_config = setup_catalog.catalog_json,
+            init_result = initialize_tables.init_json,
+            schema = schema,
+            namespace = namespace,
+            batch_size = batch_size,
+            container = container
+    }
+
+    call generate_summary {
+        input:
+            gff3_file_path = gff3_file,
+            schema = schema,
+            destination = full_destination,
+            validation_result = validate_inputs.validation_json,
+            catalog_config = setup_catalog.catalog_json,
+            init_result = initialize_tables.init_json,
+            load_stats = load_gff3.stats_json,
+            batch_size = batch_size,
+            container = container
+    }
+
+    output {
+        File summary = generate_summary.summary_json
+        File validation_report = validate_inputs.validation_json
+        File connectivity_report = check_connectivity.connectivity_json
+        File permissions_report = check_permissions.permissions_json
+        File table_init_report = initialize_tables.init_json
+        File load_statistics = load_gff3.stats_json
+    }
+}
+
+
+task validate_inputs {
+    input {
+        File gff3_file
+        String schema
+        String destination
+        String container
+    }
+    command <<<
+        set -eu
+        python3 /app/validate_inputs.py \
+            --gff3-file "~{gff3_file}" \
+            --schema "~{schema}" \
+            --destination "~{destination}" \
+            --output validation_result.json
+    >>>
+    output {
+        File validation_json = "validation_result.json"
+    }
+
+    runtime {
+        container: container
+        cpu: 2
+        memory: "4 GB"
+    }
+}
+
+
+task setup_catalog {
+    input {
+        File validation_result
+        String destination
+        String? namespace
+        String container
+    }
+    command <<<
+        set -eu
+        CATALOG_TYPE=$(python3 -c "import json; data=json.load(open('~{validation_result}')); print(data['catalog_type'])")
+        python3 /app/setup_catalog.py \
+            --catalog-type "${CATALOG_TYPE}" \
+            --destination "~{destination}" \
+            ~{if defined(namespace) then '--namespace "' + namespace + '"' else ''} \
+            --output catalog_config.json
+    >>>
+    output {
+        File catalog_json = "catalog_config.json"
+    }
+
+    runtime {
+        container: container
+        cpu: 2
+        memory: "4 GB"
+    }
+}
+
+
+task check_connectivity {
+    input {
+        File catalog_config
+        String container
+    }
+    command <<<
+        set -eu
+        python3 /app/check_connectivity.py \
+            --catalog-config "~{catalog_config}" \
+            --output connectivity_report.json
+    >>>
+    output {
+        File connectivity_json = "connectivity_report.json"
+    }
+
+    runtime {
+        container: container
+        cpu: 2
+        memory: "4 GB"
+    }
+}
+
+
+task check_permissions {
+    input {
+        File catalog_config
+        String schema
+        String? namespace
+        String container
+        File connectivity_report
+    }
+    command <<<
+        set -eu
+        python3 /app/check_permissions.py \
+            --catalog-config "~{catalog_config}" \
+            --schema "~{schema}" \
+            ~{if defined(namespace) then '--namespace "' + namespace + '"' else ''} \
+            --output permissions_report.json
+    >>>
+    output {
+        File permissions_json = "permissions_report.json"
+    }
+
+    runtime {
+        container: container
+        cpu: 2
+        memory: "4 GB"
+    }
+}
+
+
+task initialize_tables {
+    input {
+        File catalog_config
+        String schema
+        String? namespace
+        String container
+        File permissions_report
+    }
+    command <<<
+        set -eu
+        python3 /app/initialize_tables.py \
+            --catalog-config "~{catalog_config}" \
+            --schema "~{schema}" \
+            ~{if defined(namespace) then '--namespace "' + namespace + '"' else ''} \
+            --output table_init_result.json
+    >>>
+    output {
+        File init_json = "table_init_result.json"
+    }
+
+    runtime {
+        container: container
+        cpu: 2
+        memory: "4 GB"
+    }
+}
+
+
+task load_gff3 {
+    input {
+        File gff3_file
+        File catalog_config
+        File init_result
+        String schema
+        String? namespace
+        Int batch_size
+        String container
+    }
+    command <<<
+        set -eu
+        if [ -z "~{select_first([namespace, ''])}" ]; then
+            NAMESPACE=$(python3 -c "import json; data=json.load(open('~{init_result}')); print(data['namespace'])")
+        else
+            NAMESPACE="~{namespace}"
+        fi
+        python3 /app/load_gff3_wrapper.py \
+            --gff3-file "~{gff3_file}" \
+            --catalog-config "~{catalog_config}" \
+            --schema "~{schema}" \
+            --namespace "${NAMESPACE}" \
+            --batch-size ~{batch_size} \
+            --output load_stats.json
+    >>>
+    output {
+        File stats_json = "load_stats.json"
+    }
+
+    runtime {
+        container: container
+        cpu: 4
+        memory: "16 GB"
+    }
+}
+
+
+task generate_summary {
+    input {
+        File gff3_file_path
+        String schema
+        String destination
+        File validation_result
+        File catalog_config
+        File init_result
+        File load_stats
+        Int batch_size
+        String container
+    }
+    command <<<
+        set -eu
+        CATALOG_TYPE=$(python3 -c "import json; data=json.load(open('~{validation_result}')); print(data['catalog_type'])")
+        NAMESPACE=$(python3 -c "import json; data=json.load(open('~{init_result}')); print(data['namespace'])")
+        TABLES_CREATED=$(python3 -c "import json; data=json.load(open('~{init_result}')); print(','.join(data['all_tables']))")
+        FEATURES_LOADED=$(python3 -c "import json; data=json.load(open('~{load_stats}')); print(data.get('features_loaded', 0))")
+        SOURCES_LOADED=$(python3 -c "import json; data=json.load(open('~{load_stats}')); print(data.get('sources_loaded', 0))")
+        RELATIONSHIPS_LOADED=$(python3 -c "import json; data=json.load(open('~{load_stats}')); print(data.get('relationships_loaded', 0))")
+        BATCHES_PROCESSED=$(python3 -c "import json; data=json.load(open('~{load_stats}')); print(data.get('batches_processed', 0))")
+        TABLE_LOCATIONS=$(python3 -c "import json; data=json.load(open('~{init_result}')); metadata=data.get('table_metadata', {}); locations={k: v.get('location', '') for k, v in metadata.items()}; print(json.dumps(locations))")
+        START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        END_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+        python3 /app/generate_summary.py \
+            --gff3-file "~{gff3_file_path}" \
+            --schema "~{schema}" \
+            --destination "~{destination}" \
+            --namespace "${NAMESPACE}" \
+            --catalog-type "${CATALOG_TYPE}" \
+            --tables-created "${TABLES_CREATED}" \
+            --features-loaded "${FEATURES_LOADED}" \
+            --sources-loaded "${SOURCES_LOADED}" \
+            --relationships-loaded "${RELATIONSHIPS_LOADED}" \
+            --batches-processed "${BATCHES_PROCESSED}" \
+            --batch-size ~{batch_size} \
+            --start-time "${START_TIME}" \
+            --end-time "${END_TIME}" \
+            --table-locations "${TABLE_LOCATIONS}" \
+            --output summary.json
+    >>>
+    output {
+        File summary_json = "summary.json"
+    }
+
+    runtime {
+        container: container
+        cpu: 2
+        memory: "4 GB"
+    }
+}

--- a/templates/gff3-to-iceberg/metadata_schema.py
+++ b/templates/gff3-to-iceberg/metadata_schema.py
@@ -1,0 +1,156 @@
+"""
+Metadata schema for GFF3 file-level directives and pragmas.
+
+Captures GFF3 header information:
+  - gff_files: Tracks loaded GFF3 files
+  - sequence_regions: ##sequence-region directives
+  - header_metadata: All other ## directives (species, genome-build, etc.)
+"""
+
+from typing import Dict
+from pyiceberg.catalog import Catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.types import (
+    NestedField,
+    StringType,
+    LongType,
+    UUIDType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import BucketTransform
+from pyiceberg.table.sorting import (
+    SortOrder, SortField, SortDirection, NullOrder
+)
+from pyiceberg.transforms import IdentityTransform
+from utils import create_table, load_s3_tables_catalog
+
+
+# ─── gff_files table ──────────────────────────────────────────────────────────
+
+gff_files_schema: Schema = Schema(
+    NestedField(1, "file_id", UUIDType(), required=True),
+    NestedField(2, "file_name", StringType(), required=True),
+    NestedField(3, "gff_version", StringType(),
+                doc="GFF version from ##gff-version directive"),
+    NestedField(4, "created_at", LongType(), required=True,
+                doc="Epoch millis when the file was loaded"),
+)
+
+gff_files_sort_order: SortOrder = SortOrder(
+    SortField(source_id=2,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+# ─── sequence_regions table ───────────────────────────────────────────────────
+# From ##sequence-region seqid start end
+
+sequence_regions_schema: Schema = Schema(
+    NestedField(1, "region_id", UUIDType(), required=True),
+    NestedField(2, "file_id", UUIDType(), required=True),
+    NestedField(3, "seqid", StringType(), required=True),
+    NestedField(4, "start", LongType(), required=True),
+    NestedField(5, "end", LongType(), required=True),
+)
+
+sequence_regions_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=100,
+                   transform=BucketTransform(16),
+                   name="file_id_bucket"),
+)
+
+
+# ─── header_metadata table ────────────────────────────────────────────────────
+# All other ## directives: ##species, ##genome-build, etc.
+
+header_metadata_schema: Schema = Schema(
+    NestedField(1, "metadata_id", UUIDType(), required=True),
+    NestedField(2, "file_id", UUIDType(), required=True),
+    NestedField(3, "directive", StringType(), required=True,
+                doc="Directive name (e.g., species, genome-build)"),
+    NestedField(4, "value", StringType(), required=True,
+                doc="Directive value"),
+)
+
+header_metadata_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=100,
+                   transform=BucketTransform(16),
+                   name="file_id_bucket"),
+)
+
+
+def create_schema_tables(catalog: Catalog, namespace: str) -> Dict[str, Table]:
+    table_name_gff_files = "gff_files"
+    table_name_sequence_regions = "sequence_regions"
+    table_name_header_metadata = "header_metadata"
+
+    print(f"Creating metadata tables in namespace {namespace} ...")
+
+    print(f"Creating {table_name_gff_files}")
+    gff_files: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_gff_files,
+        schema=gff_files_schema,
+        partition_spec=None,
+        sort_order=gff_files_sort_order)
+    print(f"Created {gff_files}")
+
+    print(f"Creating {table_name_sequence_regions}")
+    sequence_regions: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_sequence_regions,
+        schema=sequence_regions_schema,
+        partition_spec=sequence_regions_partition_spec,
+        sort_order=None)
+    print(f"Created {sequence_regions}")
+
+    print(f"Creating {table_name_header_metadata}")
+    header_metadata: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_header_metadata,
+        schema=header_metadata_schema,
+        partition_spec=header_metadata_partition_spec,
+        sort_order=None)
+    print(f"Created {header_metadata}")
+
+    return {
+        table_name_gff_files: gff_files,
+        table_name_sequence_regions: sequence_regions,
+        table_name_header_metadata: header_metadata,
+    }
+
+
+def main():
+    from utils import create_namespace
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Create metadata tables for GFF3 annotation data')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    parser.add_argument('--namespace', required=True, help='Namespace for tables')
+    args = parser.parse_args()
+
+    print("Connecting to catalog ...")
+    catalog = load_s3_tables_catalog(args.bucket_arn)
+    print("Connected to catalog")
+
+    print("Creating namespace ...")
+    create_namespace(catalog, args.namespace)
+    print("Namespace created")
+
+    print("Creating tables ...")
+    create_schema_tables(catalog, args.namespace)
+    print("Tables created")
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/parameter-template.json
+++ b/templates/gff3-to-iceberg/parameter-template.json
@@ -1,0 +1,26 @@
+{
+  "schema": {
+    "description": "Schema design to use (1 or 2)",
+    "optional": false
+  },
+  "destination": {
+    "description": "S3 Table Bucket ARN (arn:aws:s3tables:...) or S3 path (bucket/path without s3:// prefix) for Glue catalog.",
+    "optional": false
+  },
+  "container": {
+    "description": "ECR container image URI",
+    "optional": false
+  },
+  "namespace": {
+    "description": "Iceberg namespace. Auto-determined by schema if omitted.",
+    "optional": true
+  },
+  "batch_size": {
+    "description": "Number of GFF3 records per processing batch (default: 100000)",
+    "optional": true
+  },
+  "gff3_file": {
+    "description": "S3 URI to the input GFF3 file (.gff3 or .gff3.gz)",
+    "optional": false
+  }
+}

--- a/templates/gff3-to-iceberg/requirements.txt
+++ b/templates/gff3-to-iceberg/requirements.txt
@@ -1,0 +1,4 @@
+pyiceberg>=0.9.0
+pyiceberg-core>=0.4.0
+boto3>=1.37.26
+pyarrow>=19.0.1

--- a/templates/gff3-to-iceberg/schema_1.py
+++ b/templates/gff3-to-iceberg/schema_1.py
@@ -1,0 +1,215 @@
+"""
+Schema 1: Normalized schema for GFF3 annotation data.
+
+Three tables in namespace `annotation_db`:
+
+1. features       - Core annotation features (gene, mRNA, exon, CDS, etc.)
+2. sources        - Annotation sources/programs that produced features
+3. feature_relationships - Parent-child relationships between features
+
+Partitioning:
+  - features: by seqid (chromosome) and type_bucket (128 buckets on feature type)
+  - sources: unpartitioned (small cardinality)
+  - feature_relationships: by seqid (chromosome)
+
+This design favors data integrity and minimal redundancy. Joins are required
+to traverse the feature hierarchy (gene -> mRNA -> exon/CDS).
+"""
+
+from typing import Dict
+from pyiceberg.catalog import Catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.types import (
+    NestedField,
+    StringType,
+    LongType,
+    DoubleType,
+    MapType,
+    BooleanType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import IdentityTransform, BucketTransform
+from pyiceberg.table.sorting import (
+    SortOrder, SortField, SortDirection, NullOrder
+)
+from utils import create_table, load_s3_tables_catalog
+import time
+
+
+# ─── features table ───────────────────────────────────────────────────────────
+# One row per GFF3 feature line.
+# Reserved GFF3 attributes (ID, Name, Dbxref, Ontology_term, Is_circular)
+# are extracted into dedicated columns. Remaining attributes go into the map.
+
+features_schema: Schema = Schema(
+    NestedField(1, "feature_id", StringType(), required=True,
+                doc="GFF3 ID attribute — unique identifier for this feature"),
+    NestedField(2, "seqid", StringType(), required=True,
+                doc="Landmark / chromosome identifier (GFF3 column 1)"),
+    NestedField(3, "source", StringType(), required=True,
+                doc="Source of the annotation (GFF3 column 2)"),
+    NestedField(4, "type", StringType(), required=True,
+                doc="Feature type / SO term (GFF3 column 3)"),
+    NestedField(5, "start", LongType(), required=True,
+                doc="Start position, 1-based inclusive (GFF3 column 4)"),
+    NestedField(6, "end", LongType(), required=True,
+                doc="End position, 1-based inclusive (GFF3 column 5)"),
+    NestedField(7, "score", DoubleType(),
+                doc="Score value (GFF3 column 6), null if '.'"),
+    NestedField(8, "strand", StringType(),
+                doc="Strand: +, -, ., or ? (GFF3 column 7)"),
+    NestedField(9, "phase", StringType(),
+                doc="CDS phase: 0, 1, 2, or . (GFF3 column 8)"),
+    NestedField(10, "name", StringType(),
+                doc="GFF3 Name attribute — display name"),
+    NestedField(11, "dbxref", StringType(),
+                doc="GFF3 Dbxref attribute — database cross-references (comma-separated)"),
+    NestedField(12, "ontology_term", StringType(),
+                doc="GFF3 Ontology_term attribute (comma-separated)"),
+    NestedField(13, "is_circular", BooleanType(),
+                doc="GFF3 Is_circular attribute"),
+    NestedField(14, "attributes", MapType(key_id=15,
+                                          value_id=16,
+                                          key_type=StringType(),
+                                          value_type=StringType()),
+                doc="All remaining GFF3 column 9 attributes as key-value pairs"),
+)
+
+features_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=1000,
+                   transform=IdentityTransform(),
+                   name="seqid"),
+    PartitionField(source_id=4,
+                   field_id=1001,
+                   transform=BucketTransform(128),
+                   name="type_bucket"),
+)
+
+features_sort_order: SortOrder = SortOrder(
+    SortField(source_id=5,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+# ─── sources table ────────────────────────────────────────────────────────────
+# Distinct annotation sources encountered across loaded GFF3 files.
+
+sources_schema: Schema = Schema(
+    NestedField(1, "source_name", StringType(), required=True,
+                doc="Unique source/program name from GFF3 column 2"),
+    NestedField(2, "description", StringType(),
+                doc="Optional description of the source"),
+)
+
+
+# ─── feature_relationships table ──────────────────────────────────────────────
+# Parent-child edges derived from the GFF3 Parent attribute.
+# A feature with Parent=mRNA00001,mRNA00002 produces two rows.
+
+feature_relationships_schema: Schema = Schema(
+    NestedField(1, "child_id", StringType(), required=True,
+                doc="Feature ID of the child"),
+    NestedField(2, "parent_id", StringType(), required=True,
+                doc="Feature ID of the parent"),
+    NestedField(3, "seqid", StringType(), required=True,
+                doc="Chromosome — denormalized for partition-aligned joins"),
+    NestedField(4, "child_type", StringType(),
+                doc="Feature type of the child (e.g., exon, CDS)"),
+    NestedField(5, "parent_type", StringType(),
+                doc="Feature type of the parent (e.g., gene, mRNA)"),
+)
+
+feature_relationships_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=3,
+                   field_id=1000,
+                   transform=IdentityTransform(),
+                   name="seqid"),
+)
+
+feature_relationships_sort_order: SortOrder = SortOrder(
+    SortField(source_id=2,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+def create_schema_tables(catalog: Catalog, namespace: str) -> Dict[str, Table]:
+    table_name_features = "features"
+    table_name_sources = "sources"
+    table_name_relationships = "feature_relationships"
+
+    print(f"Creating tables in namespace {namespace} ...")
+
+    print(f"Creating {table_name_features}")
+    features: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_features,
+        schema=features_schema,
+        partition_spec=features_partition_spec,
+        sort_order=features_sort_order)
+    print(f"Created {features}")
+
+    time.sleep(3)
+
+    print(f"Creating {table_name_sources}")
+    sources: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_sources,
+        schema=sources_schema,
+        partition_spec=None,
+        sort_order=None)
+    print(f"Created {sources}")
+
+    time.sleep(3)
+
+    print(f"Creating {table_name_relationships}")
+    relationships: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name_relationships,
+        schema=feature_relationships_schema,
+        partition_spec=feature_relationships_partition_spec,
+        sort_order=feature_relationships_sort_order)
+    print(f"Created {relationships}")
+
+    time.sleep(3)
+
+    return {
+        table_name_features: features,
+        table_name_sources: sources,
+        table_name_relationships: relationships,
+    }
+
+
+def main():
+    import argparse
+    from utils import create_namespace
+
+    parser = argparse.ArgumentParser(
+        description='Create Iceberg tables for GFF3 annotation data (Schema 1 — normalized)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    args = parser.parse_args()
+
+    print("Connecting to catalog ...")
+    catalog = load_s3_tables_catalog(args.bucket_arn)
+    print("Connected to catalog")
+
+    namespace = "annotation_db"
+    print("Creating namespace ...")
+    create_namespace(catalog, namespace)
+    print("Namespace created")
+
+    print("Creating tables ...")
+    create_schema_tables(catalog, namespace)
+    print("Tables created")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/schema_2.py
+++ b/templates/gff3-to-iceberg/schema_2.py
@@ -1,0 +1,144 @@
+"""
+Schema 2: Denormalized schema for GFF3 annotation data.
+
+Single table in namespace `annotation_db_2`:
+
+1. genomic_annotations - All feature data with parent info embedded
+
+Partitioning:
+  - by seqid (chromosome) and type_bucket (128 buckets on feature type)
+  - sorted by start position
+
+This design favors fast single-region queries without joins. Parent IDs are
+stored as a list directly on each feature row. Trade-off is that source
+metadata is duplicated across rows.
+"""
+
+from typing import Dict
+from pyiceberg.catalog import Catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.types import (
+    NestedField,
+    StringType,
+    LongType,
+    DoubleType,
+    MapType,
+    BooleanType,
+    ListType,
+)
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import IdentityTransform, BucketTransform
+from pyiceberg.table.sorting import (
+    SortOrder, SortField, SortDirection, NullOrder
+)
+from utils import create_table, load_s3_tables_catalog
+
+
+genomic_annotations_schema: Schema = Schema(
+    NestedField(1, "feature_id", StringType(), required=True,
+                doc="GFF3 ID attribute — unique identifier for this feature"),
+    NestedField(2, "seqid", StringType(), required=True,
+                doc="Landmark / chromosome identifier (GFF3 column 1)"),
+    NestedField(3, "source", StringType(), required=True,
+                doc="Source of the annotation (GFF3 column 2)"),
+    NestedField(4, "type", StringType(), required=True,
+                doc="Feature type / SO term (GFF3 column 3)"),
+    NestedField(5, "start", LongType(), required=True,
+                doc="Start position, 1-based inclusive (GFF3 column 4)"),
+    NestedField(6, "end", LongType(), required=True,
+                doc="End position, 1-based inclusive (GFF3 column 5)"),
+    NestedField(7, "score", DoubleType(),
+                doc="Score value (GFF3 column 6), null if '.'"),
+    NestedField(8, "strand", StringType(),
+                doc="Strand: +, -, ., or ? (GFF3 column 7)"),
+    NestedField(9, "phase", StringType(),
+                doc="CDS phase: 0, 1, 2, or . (GFF3 column 8)"),
+    NestedField(10, "name", StringType(),
+                doc="GFF3 Name attribute — display name"),
+    NestedField(11, "parent_ids", ListType(element_id=1000,
+                                           element_type=StringType(),
+                                           element_required=True),
+                doc="GFF3 Parent attribute — list of parent feature IDs"),
+    NestedField(12, "dbxref", StringType(),
+                doc="GFF3 Dbxref attribute — database cross-references (comma-separated)"),
+    NestedField(13, "ontology_term", StringType(),
+                doc="GFF3 Ontology_term attribute (comma-separated)"),
+    NestedField(14, "is_circular", BooleanType(),
+                doc="GFF3 Is_circular attribute"),
+    NestedField(15, "attributes", MapType(key_id=16,
+                                          value_id=17,
+                                          key_type=StringType(),
+                                          value_type=StringType()),
+                doc="All remaining GFF3 column 9 attributes as key-value pairs"),
+    identifier_field_ids=[1, 2, 4, 5]
+)
+
+genomic_annotations_partition_spec: PartitionSpec = PartitionSpec(
+    PartitionField(source_id=2,
+                   field_id=1001,
+                   transform=IdentityTransform(),
+                   name="seqid"),
+    PartitionField(source_id=4,
+                   field_id=1002,
+                   transform=BucketTransform(128),
+                   name="type_bucket"),
+)
+
+genomic_annotations_sort_order: SortOrder = SortOrder(
+    SortField(source_id=2,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+    SortField(source_id=5,
+              transform=IdentityTransform(),
+              direction=SortDirection.ASC,
+              null_order=NullOrder.NULLS_LAST),
+)
+
+
+def create_schema_tables(catalog: Catalog, namespace: str) -> Dict[str, Table]:
+    table_name = "genomic_annotations"
+
+    print(f"Creating tables in namespace {namespace} ...")
+    print(f"Creating {table_name}")
+    genomic_annotations: Table = create_table(
+        catalog=catalog,
+        namespace=namespace,
+        table_name=table_name,
+        schema=genomic_annotations_schema,
+        partition_spec=genomic_annotations_partition_spec,
+        sort_order=genomic_annotations_sort_order)
+    print(f"Created {genomic_annotations}")
+
+    return {
+        table_name: genomic_annotations,
+    }
+
+
+def main():
+    import argparse
+    from utils import create_namespace
+
+    parser = argparse.ArgumentParser(
+        description='Create Iceberg table for GFF3 annotation data (Schema 2 — denormalized)')
+    parser.add_argument('--bucket-arn', required=True, help='S3Tables bucket ARN')
+    args = parser.parse_args()
+
+    print("Connecting to catalog ...")
+    catalog = load_s3_tables_catalog(args.bucket_arn)
+    print("Connected to catalog")
+
+    namespace = "annotation_db_2"
+    print("Creating namespace ...")
+    create_namespace(catalog, namespace)
+    print("Namespace created")
+
+    print("Creating tables ...")
+    create_schema_tables(catalog, namespace)
+    print("Tables created")
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/gff3-to-iceberg/setup_catalog.py
+++ b/templates/gff3-to-iceberg/setup_catalog.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Catalog configuration module for HealthOmics VCF Loader workflow.
+
+This module configures the appropriate Iceberg catalog based on destination type:
+- S3 Tables catalog: REST catalog with SigV4 authentication
+- Vanilla Iceberg catalog: Glue-based catalog with S3 storage
+
+Outputs catalog configuration as JSON.
+"""
+
+import sys
+import json
+import argparse
+import re
+import boto3
+
+
+def extract_region_from_arn(arn: str) -> str:
+    """
+    Extract AWS region from an S3 Tables ARN.
+    
+    Args:
+        arn: S3 Tables ARN in format arn:aws:s3tables:region:account-id:bucket/bucket-name
+        
+    Returns:
+        AWS region string
+        
+    Raises:
+        ValueError: If ARN format is invalid or region cannot be extracted
+    """
+    # ARN format: arn:aws:s3tables:region:account-id:bucket/bucket-name
+    parts = arn.split(':')
+    
+    if len(parts) < 6:
+        raise ValueError(f"Invalid S3 Tables ARN format: {arn}")
+    
+    if parts[0] != 'arn' or parts[1] != 'aws' or parts[2] != 's3tables':
+        raise ValueError(f"Invalid S3 Tables ARN format: {arn}")
+    
+    region = parts[3]
+    
+    if not region:
+        raise ValueError(f"Invalid S3 Tables ARN: missing region in {arn}")
+    
+    return region
+
+
+def extract_region_from_s3_path(s3_path: str) -> str:
+    """
+    Extract or determine AWS region from an S3 path.
+    
+    For vanilla Iceberg catalogs, we use the current boto3 session region
+    or default to us-east-1.
+    
+    Args:
+        s3_path: S3 path in format s3://bucket/path
+        
+    Returns:
+        AWS region string
+    """
+    session = boto3.session.Session()
+    region = session.region_name
+    
+    if not region:
+        # Default to us-east-1 if no region is configured
+        region = 'us-east-1'
+    
+    return region
+
+
+def setup_s3tables_catalog(destination: str) -> dict:
+    """
+    Configure S3 Tables REST catalog with SigV4 authentication.
+    
+    Args:
+        destination: S3 Tables bucket ARN
+        
+    Returns:
+        Dictionary containing catalog configuration
+        
+    Raises:
+        ValueError: If ARN format is invalid
+    """
+    # Extract region from ARN
+    region = extract_region_from_arn(destination)
+    
+    # Build catalog configuration
+    catalog_config = {
+        "type": "rest",
+        "warehouse": destination,
+        "uri": f"https://s3tables.{region}.amazonaws.com/iceberg",
+        "rest.sigv4-enabled": "true",
+        "rest.signing-name": "s3tables",
+        "rest.signing-region": region,
+        "region": region
+    }
+    
+    return catalog_config
+
+
+def setup_vanilla_catalog(destination: str) -> dict:
+    """
+    Configure vanilla Iceberg catalog with S3 storage using AWS Glue as the catalog.
+    
+    Glue is the standard managed Iceberg catalog on AWS. It requires no extra
+    dependencies beyond what PyIceberg ships with, and works natively in
+    HealthOmics environments.
+    
+    Args:
+        destination: S3 path for warehouse location
+        
+    Returns:
+        Dictionary containing catalog configuration
+    """
+    # Determine region
+    region = extract_region_from_s3_path(destination)
+    
+    catalog_config = {
+        "type": "glue",
+        "warehouse": destination,
+        "client.region": region
+    }
+    
+    return catalog_config
+
+
+def setup_catalog(catalog_type: str, destination: str, namespace: str = None) -> dict:
+    """
+    Configure the appropriate Iceberg catalog based on catalog type.
+    
+    Args:
+        catalog_type: Type of catalog ('s3tables' or 'vanilla')
+        destination: Destination location (S3 Tables ARN or S3 path)
+        namespace: Optional Iceberg namespace
+        
+    Returns:
+        Dictionary containing catalog configuration and metadata
+        
+    Raises:
+        ValueError: If catalog_type is invalid or configuration fails
+    """
+    if catalog_type == 's3tables':
+        catalog_config = setup_s3tables_catalog(destination)
+    elif catalog_type == 'vanilla':
+        catalog_config = setup_vanilla_catalog(destination)
+    else:
+        raise ValueError(f"Invalid catalog type: {catalog_type}. Must be 's3tables' or 'vanilla'")
+    
+    # Add namespace if provided
+    if namespace:
+        catalog_config['namespace'] = namespace
+    
+    # Add metadata
+    result = {
+        'catalog_type': catalog_type,
+        'destination': destination,
+        'catalog_config': catalog_config,
+        'status': 'configured'
+    }
+    
+    return result
+
+
+def main():
+    """Main entry point for command-line usage."""
+    parser = argparse.ArgumentParser(
+        description='Configure Iceberg catalog for HealthOmics VCF Loader workflow'
+    )
+    parser.add_argument('--catalog-type', required=True, 
+                       choices=['s3tables', 'vanilla'],
+                       help='Type of catalog (s3tables or vanilla)')
+    parser.add_argument('--destination', required=True, 
+                       help='Destination location (S3 Tables ARN or S3 path)')
+    parser.add_argument('--namespace', 
+                       help='Iceberg namespace (optional)')
+    parser.add_argument('--output', 
+                       help='Output JSON file (default: stdout)')
+    
+    args = parser.parse_args()
+    
+    try:
+        # Setup catalog
+        result = setup_catalog(args.catalog_type, args.destination, args.namespace)
+        
+        # Output as JSON
+        output_json = json.dumps(result, indent=2)
+        
+        if args.output:
+            with open(args.output, 'w') as f:
+                f.write(output_json)
+            print(f"Catalog configuration successful. Results written to {args.output}")
+        else:
+            print(output_json)
+        
+        sys.exit(0)
+        
+    except Exception as e:
+        error_result = {
+            'status': 'error',
+            'error': str(e),
+            'error_type': type(e).__name__
+        }
+        
+        output_json = json.dumps(error_result, indent=2)
+        
+        if args.output:
+            with open(args.output, 'w') as f:
+                f.write(output_json)
+        
+        print(output_json, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/gff3-to-iceberg/utils.py
+++ b/templates/gff3-to-iceberg/utils.py
@@ -1,0 +1,103 @@
+import boto3
+from pyiceberg.catalog import Catalog, load_catalog
+from pyiceberg.schema import Schema
+from pyiceberg.table import Table
+from pyiceberg.table.sorting import SortOrder
+from pyiceberg.partitioning import PartitionSpec
+
+
+def create_table(catalog: Catalog,
+                 namespace: str,
+                 table_name: str,
+                 schema: Schema,
+                 partition_spec: PartitionSpec = None,
+                 sort_order: SortOrder = None) -> Table:
+    """Create an Iceberg Table given the relevant information."""
+
+    if catalog.table_exists(f"{namespace}.{table_name}"):
+        print(f"Table {namespace}.{table_name} already exists.")
+        return catalog.load_table(f"{namespace}.{table_name}")
+
+    create_table_args = {
+        "identifier": f"{namespace}.{table_name}",
+        "schema": schema,
+        "properties": {"format-version": "2"}
+    }
+
+    if partition_spec is not None:
+        create_table_args["partition_spec"] = partition_spec
+
+    if sort_order is not None:
+        create_table_args["sort_order"] = sort_order
+
+    table = catalog.create_table(**create_table_args)
+    print(f"Created table: {namespace}.{table_name}")
+    print(f"Table location: {table.location()}")
+    return table
+
+
+def create_namespace(catalog: Catalog, namespace: str) -> None:
+    """Create a namespace in the Catalog."""
+    try:
+        catalog.create_namespace(namespace)
+        print(f"Created namespace: {namespace}")
+    except Exception as e:
+        if "already exists" in str(e):
+            print(f"Namespace {namespace} already exists.")
+        else:
+            raise e
+
+
+def get_aws_account_id() -> str:
+    """Get AWS account ID using boto3."""
+    sts = boto3.client('sts')
+    return sts.get_caller_identity()['Account']
+
+
+def get_aws_region() -> str:
+    """Get AWS region using boto3."""
+    session = boto3.session.Session()
+    return session.region_name or 'us-east-1'
+
+
+def load_s3_tables_catalog(bucket_arn: str) -> Catalog:
+    """Connect to an S3 Tables Iceberg catalog."""
+    region = get_aws_region()
+    catalog_config = {
+        "type": "rest",
+        "warehouse": bucket_arn,
+        "uri": f"https://s3tables.{region}.amazonaws.com/iceberg",
+        "rest.sigv4-enabled": "true",
+        "rest.signing-name": "s3tables",
+        "rest.signing-region": region
+    }
+    catalog = load_catalog("s3tables", **catalog_config)
+    return catalog
+
+
+def retry_operation(operation, *args, max_retries=5, retry_condition=None, **kwargs):
+    """Retry an operation with exponential backoff."""
+    import time
+
+    retry_count = 0
+    last_exception = None
+
+    while retry_count < max_retries:
+        try:
+            result = operation(*args, **kwargs)
+            return result
+        except Exception as e:
+            retry_count += 1
+            last_exception = e
+
+            should_retry = retry_condition(e) if retry_condition else True
+
+            if should_retry and retry_count < max_retries:
+                print(f"Operation failed. Retry attempt {retry_count}/{max_retries}...")
+                time.sleep(retry_count * 2)
+            else:
+                raise e
+
+    if last_exception:
+        print(f"Failed after {max_retries} attempts.")
+        raise last_exception

--- a/templates/gff3-to-iceberg/validate_inputs.py
+++ b/templates/gff3-to-iceberg/validate_inputs.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Input validation module for HealthOmics GFF3 Annotation Loader workflow.
+
+Validates:
+- GFF3 file existence (S3 and local paths)
+- Schema selection (must be 1 or 2)
+- Destination format (S3 Tables ARN or S3 path)
+- Catalog type determination
+"""
+
+import os
+import sys
+import json
+import argparse
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+
+
+def parse_s3_uri(s3_uri):
+    if not s3_uri.startswith('s3://'):
+        raise ValueError(f"Invalid S3 URI format: {s3_uri}")
+    parts = s3_uri[5:].split('/', 1)
+    return parts[0], parts[1] if len(parts) > 1 else ''
+
+
+def validate_gff3_file(gff3_path):
+    if gff3_path.startswith('s3://'):
+        try:
+            bucket, key = parse_s3_uri(gff3_path)
+            s3 = boto3.client('s3')
+            s3.head_object(Bucket=bucket, Key=key)
+            return True
+        except ClientError as e:
+            code = e.response.get('Error', {}).get('Code', '')
+            if code == '404':
+                raise FileNotFoundError(f"GFF3 file not found in S3: {gff3_path}")
+            elif code == '403':
+                raise PermissionError(f"Access denied to GFF3 file: {gff3_path}")
+            else:
+                raise RuntimeError(f"Error accessing GFF3 file {gff3_path}: {e}")
+        except NoCredentialsError:
+            raise RuntimeError("AWS credentials not found.")
+    else:
+        if not os.path.exists(gff3_path):
+            raise FileNotFoundError(f"GFF3 file not found: {gff3_path}")
+        if not os.path.isfile(gff3_path):
+            raise ValueError(f"Path is not a file: {gff3_path}")
+        return True
+
+
+def validate_schema(schema):
+    try:
+        schema_int = int(schema)
+    except (ValueError, TypeError):
+        raise ValueError(f"Invalid schema selection: {schema}. Must be 1 or 2")
+    if schema_int not in [1, 2]:
+        raise ValueError(f"Invalid schema selection: {schema}. Must be 1 or 2")
+    return schema_int
+
+
+def determine_catalog_type(destination):
+    if destination.startswith('arn:aws:s3tables:'):
+        return 's3tables'
+    elif destination.startswith('s3://'):
+        return 'vanilla'
+    else:
+        raise ValueError(
+            f"Invalid destination format: {destination}. "
+            "Must be S3 Tables ARN (arn:aws:s3tables:...) or S3 path (s3://...)"
+        )
+
+
+def validate_destination(destination, catalog_type):
+    if catalog_type == 's3tables':
+        parts = destination.split(':')
+        if len(parts) < 6 or parts[0] != 'arn' or parts[2] != 's3tables' or not parts[3]:
+            raise ValueError(f"Invalid S3 Tables ARN format: {destination}")
+        return True
+    elif catalog_type == 'vanilla':
+        try:
+            bucket, _ = parse_s3_uri(destination)
+            s3 = boto3.client('s3')
+            s3.head_bucket(Bucket=bucket)
+            return True
+        except ClientError as e:
+            code = e.response.get('Error', {}).get('Code', '')
+            if code == '404':
+                raise RuntimeError(f"S3 bucket not found: {bucket}")
+            elif code == '403':
+                raise PermissionError(f"Access denied to S3 bucket: {bucket}")
+            else:
+                raise RuntimeError(f"Error accessing S3 bucket {bucket}: {e}")
+    return True
+
+
+def validate_inputs(gff3_file, schema, destination):
+    schema_int = validate_schema(schema)
+    catalog_type = determine_catalog_type(destination)
+    validate_gff3_file(gff3_file)
+    validate_destination(destination, catalog_type)
+    return {
+        'gff3_file': gff3_file,
+        'schema': schema_int,
+        'destination': destination,
+        'catalog_type': catalog_type,
+        'status': 'valid'
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Validate inputs for GFF3 Annotation Loader')
+    parser.add_argument('--gff3-file', required=True, help='Path to GFF3 file')
+    parser.add_argument('--schema', required=True, help='Schema selection (1 or 2)')
+    parser.add_argument('--destination', required=True, help='Destination (S3 Tables ARN or S3 path)')
+    parser.add_argument('--output', help='Output JSON file')
+    args = parser.parse_args()
+
+    try:
+        result = validate_inputs(args.gff3_file, args.schema, args.destination)
+        output_json = json.dumps(result, indent=2)
+        if args.output:
+            with open(args.output, 'w') as f:
+                f.write(output_json)
+            print(f"Validation successful. Results written to {args.output}")
+        else:
+            print(output_json)
+        sys.exit(0)
+    except Exception as e:
+        error_result = {'status': 'error', 'error': str(e), 'error_type': type(e).__name__}
+        output_json = json.dumps(error_result, indent=2)
+        if args.output:
+            with open(args.output, 'w') as f:
+                f.write(output_json)
+        print(output_json, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/test_data/sample.gff3
+++ b/test_data/sample.gff3
@@ -1,0 +1,33 @@
+##gff-version 3
+##sequence-region chr1 1 248956422
+##sequence-region chr2 1 242193529
+##species https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=9606
+chr1	ensembl	gene	11869	14409	.	+	.	ID=gene:ENSG00000223972;Name=DDX11L1;biotype=transcribed_unprocessed_pseudogene;description=DEAD/H-box helicase 11 like 1;Dbxref=NCBI:100287102
+chr1	ensembl	mRNA	11869	14409	.	+	.	ID=transcript:ENST00000456328;Parent=gene:ENSG00000223972;Name=DDX11L1-202;biotype=processed_transcript
+chr1	ensembl	exon	11869	12227	.	+	.	ID=exon:ENSE00002234944;Parent=transcript:ENST00000456328;Name=ENSE00002234944;rank=1
+chr1	ensembl	exon	12613	12721	.	+	.	ID=exon:ENSE00003582793;Parent=transcript:ENST00000456328;Name=ENSE00003582793;rank=2
+chr1	ensembl	exon	13221	14409	.	+	.	ID=exon:ENSE00002312635;Parent=transcript:ENST00000456328;Name=ENSE00002312635;rank=3
+chr1	ensembl	gene	14404	29570	.	-	.	ID=gene:ENSG00000227232;Name=WASH7P;biotype=unprocessed_pseudogene;description=WASP family homolog 7 pseudogene;Dbxref=NCBI:653635
+chr1	ensembl	mRNA	14404	29570	.	-	.	ID=transcript:ENST00000488147;Parent=gene:ENSG00000227232;Name=WASH7P-201;biotype=unprocessed_pseudogene
+chr1	ensembl	exon	14404	14501	.	-	.	ID=exon:ENSE00001890064;Parent=transcript:ENST00000488147;Name=ENSE00001890064;rank=1
+chr1	ensembl	exon	15005	15038	.	-	.	ID=exon:ENSE00003507205;Parent=transcript:ENST00000488147;Name=ENSE00003507205;rank=2
+chr1	ensembl	exon	15796	15947	.	-	.	ID=exon:ENSE00003477500;Parent=transcript:ENST00000488147;Name=ENSE00003477500;rank=3
+chr1	ensembl	exon	16607	16765	.	-	.	ID=exon:ENSE00003565697;Parent=transcript:ENST00000488147;Name=ENSE00003565697;rank=4
+chr1	ensembl	exon	16858	17055	.	-	.	ID=exon:ENSE00003475637;Parent=transcript:ENST00000488147;Name=ENSE00003475637;rank=5
+chr1	ensembl	exon	17233	17368	.	-	.	ID=exon:ENSE00003502542;Parent=transcript:ENST00000488147;Name=ENSE00003502542;rank=6
+chr1	ensembl	exon	17606	17742	.	-	.	ID=exon:ENSE00003553898;Parent=transcript:ENST00000488147;Name=ENSE00003553898;rank=7
+chr1	ensembl	exon	17915	18061	.	-	.	ID=exon:ENSE00003621279;Parent=transcript:ENST00000488147;Name=ENSE00003621279;rank=8
+chr1	ensembl	exon	18268	18366	.	-	.	ID=exon:ENSE00003624603;Parent=transcript:ENST00000488147;Name=ENSE00003624603;rank=9
+chr1	ensembl	exon	24738	24891	.	-	.	ID=exon:ENSE00003530919;Parent=transcript:ENST00000488147;Name=ENSE00003530919;rank=10
+chr1	ensembl	exon	29534	29570	.	-	.	ID=exon:ENSE00001863096;Parent=transcript:ENST00000488147;Name=ENSE00001863096;rank=11
+chr1	havana	gene	29554	31109	.	+	.	ID=gene:ENSG00000243485;Name=MIR1302-2HG;biotype=lncRNA;description=MIR1302-2 host gene
+chr1	havana	mRNA	29554	31097	.	+	.	ID=transcript:ENST00000473358;Parent=gene:ENSG00000243485;Name=MIR1302-2HG-202;biotype=lncRNA
+chr1	havana	exon	29554	30039	.	+	.	ID=exon:ENSE00001947070;Parent=transcript:ENST00000473358;Name=ENSE00001947070;rank=1
+chr1	havana	exon	30564	30667	.	+	.	ID=exon:ENSE00001922571;Parent=transcript:ENST00000473358;Name=ENSE00001922571;rank=2
+chr1	havana	exon	30976	31097	.	+	.	ID=exon:ENSE00001827679;Parent=transcript:ENST00000473358;Name=ENSE00001827679;rank=3
+chr2	ensembl	gene	38814	46588	.	+	.	ID=gene:ENSG00000184731;Name=FAM110C;biotype=protein_coding;description=family with sequence similarity 110 member C;Dbxref=NCBI:642273
+chr2	ensembl	mRNA	38814	46588	.	+	.	ID=transcript:ENST00000461467;Parent=gene:ENSG00000184731;Name=FAM110C-202;biotype=protein_coding
+chr2	ensembl	exon	38814	38912	.	+	.	ID=exon:ENSE00001758274;Parent=transcript:ENST00000461467;Name=ENSE00001758274;rank=1
+chr2	ensembl	CDS	38814	38912	.	+	0	ID=CDS:ENSP00000418705;Parent=transcript:ENST00000461467;protein_id=ENSP00000418705
+chr2	ensembl	exon	45440	46588	.	+	.	ID=exon:ENSE00001667363;Parent=transcript:ENST00000461467;Name=ENSE00001667363;rank=2
+chr2	ensembl	CDS	45440	46174	.	+	2	ID=CDS:ENSP00000418705.2;Parent=transcript:ENST00000461467;protein_id=ENSP00000418705


### PR DESCRIPTION
- annotation-database/: Standalone project for loading GFF3 files into Apache Iceberg tables on AWS S3 Tables using PyIceberg
  - Schema 1 (normalized): features, sources, feature_relationships tables
  - Schema 2 (denormalized): single genomic_annotations table
  - GFF3 parser with URL-decoding, reserved attribute extraction, parent-child relationship tracking, and FASTA section handling
  - Metadata schema for GFF3 directives and pragmas

- templates/gff3-to-iceberg/: HealthOmics WDL workflow template
  - 7-stage pipeline: validate, setup catalog, check connectivity, check permissions, initialize tables, load GFF3, generate summary
  - Supports S3 Tables and vanilla Iceberg (Glue catalog)
  - Dockerfile, ECR build scripts, parameter template

- test_data/sample.gff3: Sample GFF3 with 30 features across chr1/chr2 (genes, mRNAs, exons, CDS) from Ensembl and Havana sources

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
